### PR TITLE
Handle --nosound better

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -67,7 +67,7 @@ void OMW::Engine::executeLocalScripts()
 
 bool OMW::Engine::frameStarted(const Ogre::FrameEvent& evt)
 {
-	if(! (mEnvironment.mSoundManager->isMusicPlaying()))
+	if(mUseSound && !(mEnvironment.mSoundManager->isMusicPlaying()))
 	{
 		// Play some good 'ol tunes
 			mEnvironment.mSoundManager->startRandomTitle();

--- a/apps/openmw/mwsound/soundmanager.cpp
+++ b/apps/openmw/mwsound/soundmanager.cpp
@@ -364,10 +364,14 @@ namespace MWSound
 
 
     bool SoundManager::isMusicPlaying()
-   {
-	    bool test =  mData->music->isPlaying();
-		return test;
-   }
+    {
+	    bool test = false;
+        if(mData && mData->music)
+        {
+            test = mData->music->isPlaying();
+        }
+        return test;
+    }
 
    SoundManager::SoundImpl SoundManager::getMData()
   {


### PR DESCRIPTION
d38f2f0a00cd54833c38d382fb1d183309cfb662:
Fixes crash when trying to use --nosound.

ba18dc46ef0219c158b668a4616fff520f195213:
Disables attempts to play random tunes when sound is disabled.
The perceived difference is basically that it doesn't print that it is trying to play a new random tune very frequently.
