### PR TITLE
Updated file paths

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -4,7 +4,8 @@ project(OpenMW)
 
 set(GAME
     main.cpp
-    engine.cpp)
+    engine.cpp
+    path.cpp)
 set(GAME_HEADER
     engine.hpp)
 source_group(game FILES ${GAME} ${GAME_HEADER})

--- a/apps/openmw/path.cpp
+++ b/apps/openmw/path.cpp
@@ -1,0 +1,56 @@
+#include "path.hpp"
+
+#include <boost/filesystem.hpp>
+
+#if OGRE_PLATFORM == OGRE_PLATFORM_LINUX
+#include <stdlib.h> //getenv
+#endif
+
+
+std::string OMW::Path::getPath(PathTypeEnum parType, const std::string parApp, const std::string parFile)
+{
+    std::string theBasePath;
+    if(parType == GLOBAL_CFG_PATH)
+    {
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+        theBasePath = macBundlePath() + "/Contents/MacOS/"; //FIXME do we have global/local with OSX?
+#elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX
+        theBasePath = "/etc/"+parApp+"/";
+#else
+        theBasePath = "";
+#endif
+
+    }
+    else
+    {
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+        theBasePath = macBundlePath() + "/Contents/MacOS/"; //FIXME do we have global/local with OSX?
+#elif OGRE_PLATFORM == OGRE_PLATFORM_LINUX
+        const char* theDir;
+        if ((theDir = getenv("OPENMW_HOME")) != NULL)
+        {
+            theBasePath = std::string(theDir)+"/";
+        }
+        else
+        {
+            if ((theDir = getenv("XDG_CONFIG_HOME")))
+            {
+                theBasePath = std::string(theDir)+"/"+parApp+"/";
+            }
+            else
+            {
+                if ((theDir = getenv("HOME")) == NULL)
+                    return parFile;
+                theBasePath = std::string(theDir)+"/.config/"+parApp+"/";
+            }
+        }
+        boost::filesystem::create_directories(boost::filesystem::path(theBasePath));
+#else
+        theBasePath = "";
+#endif
+    }
+
+    theBasePath.append(parFile);
+    return theBasePath;
+}
+

--- a/apps/openmw/path.hpp
+++ b/apps/openmw/path.hpp
@@ -4,12 +4,6 @@
 #include <OgrePlatform.h>
 #include <string>
 
-#if OGRE_PLATFORM_LINUX
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <stdlib.h> //getenv
-#endif
-
 namespace OMW
 {
     class Path
@@ -21,46 +15,7 @@ namespace OMW
                 GLOBAL_CFG_PATH
             };
 
-            //TODO use application data dir on windows?
-            static std::string getPath(PathTypeEnum parType, const std::string parApp, const std::string parFile)
-            {
-                std::string theBasePath;
-                if(parType == GLOBAL_CFG_PATH)
-                {
-#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
-                    theBasePath = macBundlePath() + "/Contents/MacOS/"; //FIXME do we have global/local with OSX?
-#elif OGRE_PLATFORM_LINUX
-                    theBasePath = "/etc/"+parApp+"/";
-#else
-                    theBasePath = "";
-#endif
-
-                }
-                else
-                {
-#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
-                    theBasePath = macBundlePath() + "/Contents/MacOS/"; //FIXME do we have global/local with OSX?
-#elif OGRE_PLATFORM_LINUX
-                    const char* homedir;
-                    if ((homedir = getenv("OPENMW_HOME")) != NULL)
-                    {
-                        theBasePath = std::string(homedir)+"/";
-                    }
-                    else
-                    {
-                        if ((homedir = getenv("HOME")) == NULL)
-                            return NULL;
-                        theBasePath = std::string(homedir)+"/."+parApp+"/";
-                    }
-                    mkdir(theBasePath.c_str(), 0777);
-#else
-                    theBasePath = "";
-#endif
-                }
-
-                theBasePath.append(parFile);
-                return theBasePath;
-            }
+            static std::string getPath(PathTypeEnum parType, const std::string parApp, const std::string parFile);
     };
 }
 #endif


### PR DESCRIPTION
Based on comments on the forum I have changed user configuration path to follow the 'XDG Base Directory Specification'. I.e. store files in~/.config/openmw/ (or $XDG_CONFIG_HOME/openmw/ if that one is set) instead of ~/.openmw/.

Also updated based on feedback from athile:
Fix broken ifdefs for Linux detection causing problems for other platforms.
Use boost:filesystem instead of mkdir for increased future portability.
Break apart class definition and implementation.
