### PR TITLE
Removed libuuid dependency on OS X and updated README_Mac

### DIFF
--- a/README_Mac.md
+++ b/README_Mac.md
@@ -31,7 +31,7 @@ Getting OpenMW Working
 1. Clone this repository.
 2. Note about libs: I prefer not to install them globally (i. e. in /usr/local/), so I installing them in directory in my home directory. If OpenMW sources is in $HOME/path/openmw, I'm using $HOME/path/libs/root as prefix for boost and other libs.
   It's useful to create env var for lib install prefix:
-        $ export OMW_LIB_PREFIX=$HOME/path/libs
+        $ export OMW_LIB_PREFIX=$HOME/path/libs/root
 
 3. First of all, set for current terminal some env vars:
         $ export CFLAGS="-arch i386"
@@ -97,7 +97,8 @@ Getting OpenMW Working
         Create symlink to resources subdirectory:
         $ ln -s resources Contents/Resources/resources
         Create symlinks for *.cfg files:
-        $ ln -s plugins.cfg 
+        $ ln -s plugins.cfg Contents/MacOS/plugins.cfg
+        $ ln -s openmw.cfg Contents/MacOS/openmw.cfg
 
 9. Move your Morrowind `Data Files` directory into the `Contents/Resources`
    with the name `data` or create symlink:
@@ -106,6 +107,11 @@ Getting OpenMW Working
 10. From your build directory run:
         $ ./openmw
   Enjoy!
+
+11. Optionally you can create .app bundle:
+        $ make package
+  But for now you shold manually copy Contents directory from build directory to bundle
+  (because there is no plugins and resources in generated .app).
    
 
 [boost]: http://www.boost.org

--- a/README_Mac.md
+++ b/README_Mac.md
@@ -29,22 +29,28 @@ Getting OpenMW Working
 ----------------------
 
 1. Clone this repository.
-2. Install `bjam` through MacPorts.
-3. Download [boost][] 1.43 and install it with the following command:
+2. Note about libs: I prefer not to install them globally (i. e. in /usr/local/), so I installing them in directory in my home directory. If OpenMW sources is in $HOME/path/openmw, I'm using $HOME/path/libs/root as prefix for boost and other libs.
+  It's useful to create env var for lib install prefix:
+        $ export OMW_LIB_PREFIX=$HOME/path/libs
 
-        $ mkdir build && sudo bjam --build-dir=build \ 
-        --layout=versioned --toolset=darwin architecture=i386 \
-        address-model=32 --link=shared,static install
+3. First of all, set for current terminal some env vars:
+        $ export CFLAGS="-arch i386"
+        $ export CXXFLAGS="-arch i386"
+        $ export LDFLAGS="-arch i386"
+  All libs will build with correct architecture.
+  If you close your terminal, you should set env vars again before pcoceeding to next steps!
+
+4. Download [boost][] (tested with 1.45) and install it with the following command:
+
+        $ cd /path/to/boost/source
+        $ ./bootstrap.sh --prefix=$OMW_LIB_PREFIX
+        $ ./bjam --build-dir=build --layout=versioned \
+        --toolset=darwin architecture=x86 address-model=32 \
+        --link-shared,static --prefix=$OMW_LIB_PREFIX install
 
 
-4. Download [Ogre][] 1.7.1 and build and Xcode project with CMake:
-
-         $ mdkir build && cd build && \
-         BOOST_INCLUDEDIR=/usr/local/include/boost-1_43 \
-         BOOST_LIBRARYDIR=/usr/local/lib cmake -G Xcode ..
-
-5. Once the build completes, move `lib/Release/Ogre.framework` into
-   `/Library/Frameworks`.
+5. Download [Ogre][] SDK (tested with 1.7.2) and move `lib/Release/Ogre.framework` into
+  `Library/Frameworks`.
 
 6. Download [OIS][] and use the XCode project provided in
    `ois/Mac/XCode-2.2`. Be sure to set your build architecture to
@@ -52,20 +58,58 @@ Getting OpenMW Working
    builds, move `ois/Mac/XCode-2.2/build/Debug/OIS.framework` to
    `/Library/Frameworks`.
 
-7. Generate the Makefile for OpenMW as follows:
+7. Download [mpg123][] and build it:
+        $ cd /path/to/mpg123/source
+        $ ./configure --prefix=$OMW_LIB_PREFIX --disable-debug \
+        --disable-dependency-tracking \
+        --with-optimization=4 \
+        --with-audio=coreaudio \
+        --with-default-audio=coreaudio \
+        --with-cpu=sse_alone \
+        $ make install
 
-        $ mkdir build && cd build && \
-        BOOST_INCLUDEDIR=/usr/local/include/boost-1_43 \
-        BOOST_LIBRARYDIR=/usr/local/lib CMAKE_OSX_ARCHITECTURES=i386 \
-        cmake ..
+8. Download [libsndfile][] and build it:
+        $ cd /path/to/libsndfile/source
+        $ ./configure --prefix=$OMW_LIB_PREFIX \
+        --disable-dependency-tracking
+        $make install 
 
-8. Move your Morrowind `Data Files` directory into the root `openmw`
-   directory with the name `data`. Symlink it into the build directory.
+7. Generate the Makefile for OpenMW as follows and build OpenMW:
+        $ mkdir /path/to/openmw/build/dir
+        $ cd /path/to/open/build/dir
+        $ CMAKE_OSX_ARCHITECTURES=i386 \
+        BOOST_INCLUDEDIR=$OMW_LIB_PREFIX/include/boost-1_45 \
+        BOOST_LIBRARYDIR=$OMW_LIB_PREFIX/lib \
+        cmake -D SNDFILE_INCLUDE_DIR=$OMW_LIB_PREFIX/include \
+        -D SNDFILE_LIBRARY=$OMW_LIB_PREFIX/lib/libsndfile.a \
+        -D MPG123_INCLUDE_DIR=$OMW_LIB_PREFIX/include \
+        -D MPG123_LIBRARY=$OMW_LIB_PREFIX/lib/libmpg123.a \
+        -G "Unix Makefiles" /path/to/openmw/source
+        $ make
+        
+8. In build directory create directory for game resources:
+        $ cd /path/to/openmw/build/dir
+        $ mkdir Contents
+        $ mkdir Contents/Resources
+        $ mkdir Contents/Plugins
+        Copy Ogre plugins from Ogre SDK to Plugins subdir:
+        $ cp /path/to/ogre/sdk/lib/*.dylib Contents/Plugins
+        Create symlink to resources subdirectory:
+        $ ln -s resources Contents/Resources/resources
+        Create symlinks for *.cfg files:
+        $ ln -s plugins.cfg 
 
-        $ cd build && ln -s ../data data
+9. Move your Morrowind `Data Files` directory into the `Contents/Resources`
+   with the name `data` or create symlink:
+        $ ln -s /path/to/morrowind/data/files Contents/Resources/data
+
+10. From your build directory run:
+   
 
 [boost]: http://www.boost.org
 [Ogre]: http://www.ogre3d.org
 [OIS]: http://wgois.sf.net
+[mpg123]: http://www.mpg123.de
+[libsndfile]: http://www.mega-nerd.com/libsndfile
 [official website]: http://openmw.com
 [Will Thimbleby's Ogre Framework]: http://www.thimbleby.net/ogre/

--- a/README_Mac.md
+++ b/README_Mac.md
@@ -72,7 +72,7 @@ Getting OpenMW Working
         $ cd /path/to/libsndfile/source
         $ ./configure --prefix=$OMW_LIB_PREFIX \
         --disable-dependency-tracking
-        $make install 
+        $ make install 
 
 7. Generate the Makefile for OpenMW as follows and build OpenMW:
         $ mkdir /path/to/openmw/build/dir

--- a/README_Mac.md
+++ b/README_Mac.md
@@ -104,6 +104,8 @@ Getting OpenMW Working
         $ ln -s /path/to/morrowind/data/files Contents/Resources/data
 
 10. From your build directory run:
+        $ ./openmw
+  Enjoy!
    
 
 [boost]: http://www.boost.org

--- a/extern/mygui_3.0.1/MyGUIEngine/CMakeLists.txt
+++ b/extern/mygui_3.0.1/MyGUIEngine/CMakeLists.txt
@@ -25,7 +25,10 @@ if (MYGUI_USE_FREETYPE)
 	)
 endif()
 
-target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS} uuid)
+# We don't need this lib in OS X. uuid functions is in libc here.
+if (NOT APPLE)
+	target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS} uuid)
+endif(NOT APPLE)
 
 if (MINGW)
   target_link_libraries(${PROJECT_NAME} libwinmm.a)


### PR DESCRIPTION
We don't need to link with libuuid on OS X because uuid functions is in libc here.
