### PR TITLE
Gui Delegate

### DIFF
--- a/apps/openmw/mwgui/review.cpp
+++ b/apps/openmw/mwgui/review.cpp
@@ -114,7 +114,7 @@ void ReviewDialog::onScrollChangePosition(MyGUI::VScrollPtr scroller, size_t pos
     }
 }
 
-void ReviewDialog::onWindowResize(MyGUI::WidgetPtr window)
+void ReviewDialog::onWindowResize(MyGUI::Window* window)
 {
     updateScroller();
 }

--- a/apps/openmw/mwgui/review.hpp
+++ b/apps/openmw/mwgui/review.hpp
@@ -85,7 +85,7 @@ namespace MWGui
         void updateSkillArea();
 
         void onScrollChangePosition(MyGUI::VScrollPtr scroller, size_t pos);
-        void onWindowResize(MyGUI::WidgetPtr window);
+        void onWindowResize(MyGUI::Window* window);
 
         static const int lineHeight;
 

--- a/apps/openmw/mwgui/stats_window.cpp
+++ b/apps/openmw/mwgui/stats_window.cpp
@@ -76,7 +76,7 @@ void StatsWindow::onScrollChangePosition(MyGUI::VScrollPtr scroller, size_t pos)
     }
 }
 
-void StatsWindow::onWindowResize(MyGUI::WidgetPtr window)
+void StatsWindow::onWindowResize(MyGUI::Window* window)
 {
     updateScroller();
 }

--- a/apps/openmw/mwgui/stats_window.hpp
+++ b/apps/openmw/mwgui/stats_window.hpp
@@ -58,7 +58,7 @@ namespace MWGui
             void updateScroller();
 
             void onScrollChangePosition(MyGUI::VScrollPtr scroller, size_t pos);
-            void onWindowResize(MyGUI::WidgetPtr window);
+            void onWindowResize(MyGUI::Window* window);
 
             static const int lineHeight;
 


### PR DESCRIPTION
Changed the parameter type in order to get rid of deprecated warnings.

warning: ‘void MyGUI::EventPair<EventObsolete, Event>::operator=(T_) [with T = MyGUI::delegates::IDelegate1<MyGUI::Widget_>, EventObsolete = MyGUI::delegates::CDelegate1MyGUI::Widget*, Event = MyGUI::delegates::CDelegate1MyGUI::Window*]’ is deprecated (declared at MyGUIEngine/include/MyGUI_EventPair.h:38)
