### PR TITLE
Fixed CMake bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,7 @@ if (WIN32)
 configure_file(${OpenMW_SOURCE_DIR}/files/plugins.cfg.win32
     "${OpenMW_BINARY_DIR}/plugins.cfg" COPYONLY)
 endif (WIN32)
-if (LINUX)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 configure_file(${OpenMW_SOURCE_DIR}/files/plugins.cfg.linux
     "${OpenMW_BINARY_DIR}/plugins.cfg")
 endif (LINUX)


### PR DESCRIPTION
Hey Zini. 

I tried to reproduce the problem with the plugins.cfg missing and I was right, it really doesn't get copied.
As it turns out: there is no if (LINUX) in CMake, as this blog post points out:
http://www.openguru.com/2009/04/cmake-detecting-platformoperating.html

Don't know why this bug didn't show up before.

Regards,
Pieter.
