### PR TITLE
Add mac-specific include to main.cpp

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -44,10 +44,6 @@
 
 #include <OgreRoot.h>
 
-#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
-#include <OSX/macUtils.h>
-#endif
-
 #include <MyGUI_WidgetManager.h>
 #include "mwgui/class.hpp"
 

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -26,6 +26,11 @@
 
 #endif
 
+// for Ogre::macBundlePath
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+#include <OSX/macUtils.h>
+#endif
+
 using namespace std;
 
 /// Parse command line options and openmw.cfg file (if one exists). Results are directly


### PR DESCRIPTION
Looks like I should add include for using Ogre::macBundlePath in main.cpp and remove such include from engine.cpp because it no longer needed here due to refactoring.
