### PR TITLE
Forcing to build with 10.6 SDK, even on newer OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ project(OpenMW)
 
 IF (APPLE)
     set(APP_BUNDLE_DIR "${OpenMW_BINARY_DIR}/OpenMW.app")
+    
+    # using 10.6 sdk
+    set(CMAKE_OSX_SYSROOT "/Developer/SDKs/MacOSX10.6.sdk")
 ENDIF (APPLE)
 
 # Sound source selection


### PR DESCRIPTION
I need to do this because:
0) I've moved to 10.7 :)
1) Most of users still on 10.6, so we need give them build for 10.6.
2) In 10.7 SDK strnlen function SUDDENLY appeared, so we don't need own implementation in libs/platform/string.h on 10.7 SDK.

So I think forcing to build against 10.6 SDK is the best solution now.
