### PR TITLE
Use Linux path handling for FreeBSD as well

### DIFF
--- a/components/files/linuxpath.cpp
+++ b/components/files/linuxpath.cpp
@@ -22,7 +22,7 @@
 
 #include "linuxpath.hpp"
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 
 #include <cstdlib>
 #include <cstring>
@@ -157,4 +157,4 @@ boost::filesystem::path LinuxPath::getRuntimeDataPath() const
 
 } /* namespace Files */
 
-#endif /* defined(__linux__) */
+#endif /* defined(__linux__) || defined(__FreeBSD__) */

--- a/components/files/linuxpath.hpp
+++ b/components/files/linuxpath.hpp
@@ -23,7 +23,7 @@
 #ifndef COMPONENTS_FILES_LINUXPATH_H
 #define COMPONENTS_FILES_LINUXPATH_H
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 
 #include <boost/filesystem.hpp>
 
@@ -85,6 +85,6 @@ struct LinuxPath
 
 } /* namespace Files */
 
-#endif /* defined(__linux__) */
+#endif /* defined(__linux__) || defined(__FreeBSD__) */
 
 #endif /* COMPONENTS_FILES_LINUXPATH_H */

--- a/components/files/path.hpp
+++ b/components/files/path.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <boost/filesystem.hpp>
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
     #include <components/files/linuxpath.hpp>
     namespace Files { typedef LinuxPath TargetPathType; }
 


### PR DESCRIPTION
This is the only change needed to run openmw on FreeBSD. Maybe linuxpath should be renamed to e.g. unixpath and used by default as there are many more OSes which may use it, including other *BSDs
