### PR TITLE
Configuration cleanup with tokens processing

### DIFF
--- a/apps/launcher/datafilespage.cpp
+++ b/apps/launcher/datafilespage.cpp
@@ -135,6 +135,8 @@ void DataFilesPage::setupDataFiles(const QStringList &paths, bool strict)
         dataDirs.push_back(boost::filesystem::path(currentPath.toStdString()));
     }
 
+    mCfgMgr.processPaths(dataDirs);
+
     // Create a file collection for the dataDirs
     Files::Collections mFileCollections(dataDirs, strict);
 

--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -197,15 +197,16 @@ OMW::Engine::~Engine()
 void OMW::Engine::loadBSA()
 {
     const Files::MultiDirCollection& bsa = mFileCollections.getCollection (".bsa");
-
-    for (Files::MultiDirCollection::TIter iter (bsa.begin()); iter!=bsa.end(); ++iter)
+    std::string dataDirectory;
+    for (Files::MultiDirCollection::TIter iter(bsa.begin()); iter!=bsa.end(); ++iter)
     {
         std::cout << "Adding " << iter->second.string() << std::endl;
-        Bsa::addBSA (iter->second.string());
-    }
+        Bsa::addBSA(iter->second.string());
 
-    //std::cout << "Data dir " << mDataDir.string() << std::endl;
-    //Bsa::addDir(mDataDir.string(), mFSStrict);
+        dataDirectory = iter->second.parent_path().string();
+        std::cout << "Data dir " << dataDirectory << std::endl;
+        Bsa::addDir(dataDirectory, mFSStrict);
+    }
 }
 
 // add resources directory

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -167,7 +167,7 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
 
     if (dataDirs.empty())
     {
-        dataDirs.push_back(cfgMgr.getLocalDataPath());
+        dataDirs.push_back(cfgMgr.getLocalPath());
     }
 
     engine.setDataDirs(dataDirs);

--- a/components/file_finder/search.cpp
+++ b/components/file_finder/search.cpp
@@ -4,25 +4,33 @@
 
 void FileFinder::find(const boost::filesystem::path & dir_path, ReturnPath &ret, bool recurse)
 {
-    if ( !boost::filesystem::exists( dir_path ) )
+    if (boost::filesystem::exists(dir_path))
     {
-      std::cout << "Path " << dir_path << " not found" << std::endl;
-      return;
-    }
-
-    boost::filesystem::directory_iterator end_itr; // default construction yields past-the-end
-    for (boost::filesystem::directory_iterator itr(dir_path); itr != end_itr; ++itr)
-    {
-        if (boost::filesystem::is_directory( *itr ))
+        if (!recurse)
         {
-            if (recurse)
+            boost::filesystem::directory_iterator end_itr; // default construction yields past-the-end
+            for (boost::filesystem::directory_iterator itr(dir_path); itr != end_itr; ++itr)
             {
-                find(*itr, ret);
+                if (!boost::filesystem::is_directory( *itr ))
+                {
+                    ret.add(*itr);
+                }
             }
         }
         else
         {
-            ret.add(*itr);
+            boost::filesystem::recursive_directory_iterator end_itr; // default construction yields past-the-end
+            for (boost::filesystem::recursive_directory_iterator itr(dir_path); itr != end_itr; ++itr)
+            {
+                if (!boost::filesystem::is_directory(*itr))
+                {
+                    ret.add(*itr);
+                }
+            }
         }
+    }
+    else
+    {
+        std::cout << "Path " << dir_path << " not found" << std::endl;
     }
 }

--- a/components/files/fixedpath.hpp
+++ b/components/files/fixedpath.hpp
@@ -86,6 +86,7 @@ struct FixedPath
             mGlobalPath /= suffix;
 
             mLocalDataPath /= suffix;
+            mUserDataPath /= suffix;
             mGlobalDataPath /= suffix;
         }
     }

--- a/components/files/fixedpath.hpp
+++ b/components/files/fixedpath.hpp
@@ -73,9 +73,7 @@ struct FixedPath
         , mUserPath(mPath.getUserPath())
         , mGlobalPath(mPath.getGlobalPath())
         , mLocalPath(mPath.getLocalPath())
-        , mUserDataPath(mPath.getUserDataPath())
         , mGlobalDataPath(mPath.getGlobalDataPath())
-        , mLocalDataPath(mPath.getLocalDataPath())
         , mInstallPath(mPath.getInstallPath())
     {
         if (!application_name.empty())
@@ -84,9 +82,6 @@ struct FixedPath
 
             mUserPath /= suffix;
             mGlobalPath /= suffix;
-
-            mLocalDataPath /= suffix;
-            mUserDataPath /= suffix;
             mGlobalDataPath /= suffix;
         }
     }
@@ -131,16 +126,6 @@ struct FixedPath
         return mGlobalDataPath;
     }
 
-    const boost::filesystem::path& getUserDataPath() const
-    {
-        return mUserDataPath;
-    }
-
-    const boost::filesystem::path& getLocalDataPath() const
-    {
-        return mLocalDataPath;
-    }
-
     private:
         PathType mPath;
 
@@ -148,11 +133,8 @@ struct FixedPath
         boost::filesystem::path mGlobalPath;     /**< Global path */
         boost::filesystem::path mLocalPath;      /**< It is the same directory where application was run */
 
-        boost::filesystem::path mUserDataPath;          /**< User data path */
         boost::filesystem::path mGlobalDataPath;        /**< Global application data path */
-        boost::filesystem::path mLocalDataPath;         /**< Local path to the configuration files.
-                                                              By default it is a 'data' directory in same
-                                                              directory where application was run */
+
         boost::filesystem::path mInstallPath;
 
 };

--- a/components/files/linuxpath.cpp
+++ b/components/files/linuxpath.cpp
@@ -41,29 +41,19 @@ boost::filesystem::path LinuxPath::getUserPath() const
     boost::filesystem::path userPath(".");
     boost::filesystem::path suffix("/");
 
-    const char* theDir = getenv("OPENMW_CONFIG");
+    const char* theDir = getenv("HOME");
     if (theDir == NULL)
     {
-        theDir = getenv("XDG_CONFIG_HOME");
-        if (theDir == NULL)
+        struct passwd* pwd = getpwuid(getuid());
+        if (pwd != NULL)
         {
-            theDir = getenv("HOME");
-            if (theDir == NULL)
-            {
-                struct passwd* pwd = getpwuid(getuid());
-                if (pwd != NULL)
-                {
-                    theDir = pwd->pw_dir;
-                }
-            }
-            if (theDir != NULL)
-            {
-                suffix = boost::filesystem::path("/.config/");
-            }
+            theDir = pwd->pw_dir;
         }
     }
 
-    if (theDir != NULL) {
+    if (theDir != NULL)
+    {
+        suffix = boost::filesystem::path("/.config/");
         userPath = boost::filesystem::path(theDir);
     }
 
@@ -74,20 +64,7 @@ boost::filesystem::path LinuxPath::getUserPath() const
 
 boost::filesystem::path LinuxPath::getGlobalPath() const
 {
-    boost::filesystem::path globalPath("/etc/xdg/");
-
-    char* theDir = getenv("XDG_CONFIG_DIRS");
-    if (theDir != NULL)
-    {
-        // We take only first path from list
-        char* ptr = strtok(theDir, ":");
-        if (ptr != NULL)
-        {
-            globalPath = boost::filesystem::path(ptr);
-            globalPath /= boost::filesystem::path("/");
-        }
-    }
-
+    boost::filesystem::path globalPath("/etc/");
     return globalPath;
 }
 
@@ -96,63 +73,10 @@ boost::filesystem::path LinuxPath::getLocalPath() const
     return boost::filesystem::path("./");
 }
 
-boost::filesystem::path LinuxPath::getUserDataPath() const
-{
-    boost::filesystem::path localDataPath(".");
-    boost::filesystem::path suffix("/");
-
-    const char* theDir = getenv("OPENMW_DATA");
-    if (theDir == NULL)
-    {
-        theDir = getenv("XDG_DATA_HOME");
-        if (theDir == NULL)
-        {
-            theDir = getenv("HOME");
-            if (theDir == NULL)
-            {
-                struct passwd* pwd = getpwuid(getuid());
-                if (pwd != NULL)
-                {
-                    theDir = pwd->pw_dir;
-                }
-            }
-            if (theDir != NULL)
-            {
-                suffix = boost::filesystem::path("/.local/share/");
-            }
-        }
-    }
-
-    if (theDir != NULL) {
-        localDataPath = boost::filesystem::path(theDir);
-    }
-
-    localDataPath /= suffix;
-    return localDataPath;
-}
-
 boost::filesystem::path LinuxPath::getGlobalDataPath() const
 {
-    boost::filesystem::path globalDataPath("/usr/local/share/");
-
-    char* theDir = getenv("XDG_DATA_DIRS");
-    if (theDir != NULL)
-    {
-        // We take only first path from list
-        char* ptr = strtok(theDir, ":");
-        if (ptr != NULL)
-        {
-            globalDataPath = boost::filesystem::path(ptr);
-            globalDataPath /= boost::filesystem::path("/");
-        }
-    }
-
+    boost::filesystem::path globalDataPath("/usr/share/games/");
     return globalDataPath;
-}
-
-boost::filesystem::path LinuxPath::getLocalDataPath() const
-{
-    return boost::filesystem::path("./data/");
 }
 
 boost::filesystem::path LinuxPath::getInstallPath() const
@@ -211,7 +135,8 @@ boost::filesystem::path LinuxPath::getInstallPath() const
 
             if (!mwpath.empty())
             {
-                // Change drive letter to lowercase, so we could use ~/.wine/dosdevice symlinks
+                // Change drive letter to lowercase, so we could use
+                // ~/.wine/dosdevices symlinks
                 mwpath[0] = tolower(mwpath[0]);
                 installPath /= homePath;
                 installPath /= ".wine/dosdevices/";

--- a/components/files/linuxpath.hpp
+++ b/components/files/linuxpath.hpp
@@ -65,21 +65,7 @@ struct LinuxPath
      *
      * \return boost::filesystem::path
      */
-    boost::filesystem::path getUserDataPath() const;
-
-    /**
-     * \brief
-     *
-     * \return boost::filesystem::path
-     */
     boost::filesystem::path getGlobalDataPath() const;
-
-    /**
-     * \brief
-     *
-     * \return boost::filesystem::path
-     */
-    boost::filesystem::path getLocalDataPath() const;
 
     /**
      * \brief Gets the path of the installed Morrowind version if there is one.

--- a/components/files/macospath.cpp
+++ b/components/files/macospath.cpp
@@ -29,6 +29,10 @@
 #include <unistd.h>
 
 /**
+ * FIXME: Someone with MacOS system should check this and correct if necessary
+ */
+
+/**
  * \namespace Files
  */
 namespace Files
@@ -69,52 +73,12 @@ boost::filesystem::path MacOsPath::getLocalPath() const
     return boost::filesystem::path("./");
 }
 
-boost::filesystem::path MacOsPath::getUserDataPath() const
-{
-    boost::filesystem::path localDataPath(".");
-    boost::filesystem::path suffix("/");
-
-    const char* theDir = getenv("OPENMW_DATA");
-    if (theDir == NULL)
-    {
-        theDir = getenv("HOME");
-        if (theDir == NULL)
-        {
-            struct passwd* pwd = getpwuid(getuid());
-            if (pwd != NULL)
-            {
-                theDir = pwd->pw_dir;
-            }
-        }
-        if (theDir != NULL)
-        {
-            suffix = boost::filesystem::path("/Library/Application Support/");
-        }
-    }
-
-    if (theDir != NULL)
-    {
-        localDataPath = boost::filesystem::path(theDir);
-    }
-
-    localDataPath /= suffix;
-    return localDataPath;
-}
-
 boost::filesystem::path MacOsPath::getGlobalDataPath() const
 {
     boost::filesystem::path globalDataPath("/Library/Application Support/");
     return globalDataPath;
 }
 
-boost::filesystem::path MacOsPath::getLocalDataPath() const
-{
-    return boost::filesystem::path("./data/");
-}
-
-/**
- * FIXME: This should be verified on MacOS system!
- */
 boost::filesystem::path MacOsPath::getInstallPath() const
 {
     boost::filesystem::path installPath;

--- a/components/files/macospath.hpp
+++ b/components/files/macospath.hpp
@@ -60,6 +60,13 @@ struct MacOsPath
      */
     boost::filesystem::path getLocalPath() const;
 
+    /**
+     * \brief
+     *
+     * \return boost::filesystem::path
+     */
+    boost::filesystem::path getGlobalDataPath() const;
+
     boost::filesystem::path getInstallPath() const;
 };
 

--- a/components/files/windowspath.cpp
+++ b/components/files/windowspath.cpp
@@ -10,6 +10,13 @@
 
 #pragma comment(lib, "Shlwapi.lib")
 
+/**
+ * FIXME: Someone with Windows system should check this and correct if necessary
+ */
+
+/**
+ * \namespace Files
+ */
 namespace Files
 {
 
@@ -55,28 +62,9 @@ boost::filesystem::path WindowsPath::getLocalPath() const
     return boost::filesystem::path("./");
 }
 
-/**
- * FIXME: Someone with Windows system should check this and correct if necessary
- */
-boost::filesystem::path WindowsPath::getUserDataPath() const
-{
-    return getUserConfigPath();
-}
-
-/**
- * FIXME: Someone with Windows system should check this and correct if necessary
- */
 boost::filesystem::path WindowsPath::getGlobalDataPath() const
 {
     return getGlobalConfigPath();
-}
-
-/**
- * FIXME: Someone with Windows system should check this and correct if necessary
- */
-boost::filesystem::path WindowsPath::getLocalDataPath() const
-{
-    return boost::filesystem::path("./data/");
 }
 
 boost::filesystem::path WindowsPath::getInstallPath() const

--- a/components/files/windowspath.hpp
+++ b/components/files/windowspath.hpp
@@ -39,7 +39,8 @@ namespace Files
 struct WindowsPath
 {
     /**
-     * \brief Returns "X:\Documents And Settings\<User name>\My Documents\My Games\"
+     * \brief Returns user path i.e.:
+     * "X:\Documents And Settings\<User name>\My Documents\My Games\"
      *
      * \return boost::filesystem::path
      */
@@ -61,26 +62,11 @@ struct WindowsPath
     boost::filesystem::path getLocalPath() const;
 
     /**
-     * \brief Return same path like getUserConfigPath
-     *
-     * \return boost::filesystem::path
-     */
-    boost::filesystem::path getUserDataPath() const;
-
-    /**
      * \brief Return same path like getGlobalConfigPath
      *
      * \return boost::filesystem::path
      */
     boost::filesystem::path getGlobalDataPath() const;
-
-    /**
-     * \brief Return runtime data path which is a location where
-     * an application was started with 'data' suffix.
-     *
-     * \return boost::filesystem::path
-     */
-    boost::filesystem::path getLocalDataPath() const;
 
     /**
      * \brief Gets the path of the installed Morrowind version if there is one.


### PR DESCRIPTION
Hi,
in this pull request there are changes related to configuration clean-up (with tokens). There is also one revert on the top of this branch because I have accidentally pushed workaround for ogre 1.8 to config branch.

When user pass --data command line parameter with some token i.e. ?local:data?/foo/bar/baz then it will be assigned to proper member variable in FixedPath class, and it could be retrieved later by using get*DataPath() ot getInstallPath() methods.
