### PR TITLE
Config fixes

### DIFF
--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -160,7 +160,6 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     engine.enableFSStrict(variables["fs-strict"].as<bool>());
 
     Files::PathContainer dataDirs(variables["data"].as<Files::PathContainer>());
-    cfgMgr.processPaths(dataDirs);
 
     std::string local(variables["data-local"].as<std::string>());
     if (!local.empty())
@@ -172,6 +171,8 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     {
         dataDirs.push_back(cfgMgr.getLocalPath());
     }
+
+    cfgMgr.processPaths(dataDirs);
 
     engine.setDataDirs(dataDirs);
 

--- a/components/files/windowspath.cpp
+++ b/components/files/windowspath.cpp
@@ -64,7 +64,7 @@ boost::filesystem::path WindowsPath::getLocalPath() const
 
 boost::filesystem::path WindowsPath::getGlobalDataPath() const
 {
-    return getGlobalConfigPath();
+    return getGlobalPath();
 }
 
 boost::filesystem::path WindowsPath::getInstallPath() const


### PR DESCRIPTION
Hi,
in this pull request there are 2 fixes - first one is for windows compilation error (I don't have windows at this moment and overlooked this), and second one is for token handling in data-local config option.

There is still a problem with boost-1.40 (i.e. in Ubuntu 10.x) because it can't handle whitespaces in paths,
and I don't have solution for this.
