### PR TITLE
Fix for Windows non-standard erase function

### DIFF
--- a/apps/openmw/mwrender/actors.cpp
+++ b/apps/openmw/mwrender/actors.cpp
@@ -103,7 +103,11 @@ void Actors::removeCell(MWWorld::Ptr::CellStore* store){
     {
         if(iter->first.getCell() == store){
             delete iter->second;
+#ifdef _WIN32
+            iter = mAllActors.erase(iter);
+#else
             mAllActors.erase(iter++);
+#endif
         }
         else
             ++iter;


### PR DESCRIPTION
Because there's the right way to do something and then there's the Microsoft way.
