### PR TITLE
Defeat

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -46,7 +46,7 @@ MainDialog::MainDialog()
     setMinimumSize(QSize(575, 575));
 
     // Load the stylesheet
-    QString config = QString::fromStdString((mCfgMgr.getGlobalDataPath() / "launcher.qss").string());
+    QString config = QString::fromStdString((mCfgMgr.getGlobalDataPath() / "resources/launcher.qss").string());
     QFile file(config);
 
     if (!file.exists()) {


### PR DESCRIPTION
It turns getGlobalDataPath returns a path without /resources so I added it. Needs to be checked with Mac but it should at least work on Linux and Mac.
