### PR TITLE
Add a notification when the journal is updated

### DIFF
--- a/apps/openmw/mwdialogue/journal.cpp
+++ b/apps/openmw/mwdialogue/journal.cpp
@@ -3,6 +3,9 @@
 
 #include "../mwworld/environment.hpp"
 
+#include "../mwgui/window_manager.hpp"
+#include "../mwgui/messagebox.hpp"
+
 namespace MWDialogue
 {
     Quest& Journal::getQuest (const std::string& id)
@@ -34,6 +37,10 @@ namespace MWDialogue
         Quest& quest = getQuest (id);
 
         quest.addEntry (entry, *mEnvironment.mWorld); // we are doing slicing on purpose here
+        
+        std::vector<std::string> empty;
+        std::string notification = "Your Journal has been updated.";
+        mEnvironment.mWindowManager->messageBox (notification, empty);
     }
 
     void Journal::setJournalIndex (const std::string& id, int index)


### PR DESCRIPTION
Alternatively we could put this as a one liner in line 34 of mwscript/dialogueextensions.cpp
context.messageBox (std::string("Your Journal has been updated."));
and it achieves the same effect. I wasn't sure where to put it so I placed it lower in the stack, since I didn't know whether addTopic was going to be called by a different function at some point. Feel free to place it there instead, if you think it's a better place.
