### PR TITLE
Fix for not visible pthreads function with glibc 2.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,11 @@ endif (APPLE)
 
 # Dependencies
 
+# Fix for not visible pthreads functions for linker with glibc 2.15 
+if (UNIX AND NOT APPLE)
+find_package (Threads)
+endif()
+
 find_package(OGRE REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options thread)
 find_package(OIS REQUIRED)

--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -81,7 +81,7 @@ add_definitions(${SOUND_DEFINE})
 
 target_link_libraries(openmw
     ${OGRE_LIBRARIES}
-	${OGRE_STATIC_PLUGINS}
+    ${OGRE_STATIC_PLUGINS}
     ${OIS_LIBRARIES}
     ${Boost_LIBRARIES}
     ${OPENAL_LIBRARY}
@@ -91,6 +91,11 @@ target_link_libraries(openmw
     MyGUIEngine
     MyGUIOgrePlatform
 )
+
+# Fix for not visible pthreads functions for linker with glibc 2.15 
+if (UNIX AND NOT APPLE)
+target_link_libraries(openmw ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 if(APPLE)
     find_library(CARBON_FRAMEWORK Carbon)


### PR DESCRIPTION
Linking error will appear:

Linking CXX executable ../../openmw
/usr/bin/ld: CMakeFiles/openmw.dir/**/**/components/bsa/bsa_archive.cpp.o: undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.2.5'
/usr/bin/ld: note: 'pthread_mutexattr_settype@@GLIBC_2.2.5' is defined in DSO /lib/libpthread.so.0 so try adding it to the linker command line
/lib/libpthread.so.0: could not read symbols: Invalid operation
collect2: ld returned 1 exit status

if we don't add explicitly pthreads library to linker flags
after update glibc to version 2.15 on (Arch) Linux.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
