### PR TITLE
Fix Bug #1: "Meshes rendered with wrong orientation"

### DIFF
--- a/components/nif/nif_file.cpp
+++ b/components/nif/nif_file.cpp
@@ -162,6 +162,15 @@ void NIFFile::parse()
       r->recName = rec;
       records[i] = r;
       r->read(this);
+
+      // Discard tranformations for the root node, otherwise some meshes
+      // occasionally get wrong orientation. Only for NiNode-s for now, but
+      // can be expanded if needed.
+      // This should be rewritten when the method is cleaned up.
+      if (0 == i && rec == "NiNode")
+      {
+          static_cast<Nif::Node*>(r)->trafo = Nif::Transformation::getIdentity();
+      }
     }
 
   /* After the data, the nif contains an int N and then a list of N

--- a/components/nif/nif_types.hpp
+++ b/components/nif/nif_types.hpp
@@ -62,17 +62,18 @@ struct Transformation
 
   static const Transformation* getIdentity()
   {
-	  static Transformation* identity = NULL;
-	  if (NULL == identity)
+	  static Transformation identity;
+      static bool iset = false;
+	  if (!iset)
       {
-        identity = new Transformation();
-        identity->scale = 1.0f;
-        identity->rotation.v[0].array[0] = 1.0f;
-        identity->rotation.v[1].array[1] = 1.0f;
-        identity->rotation.v[2].array[2] = 1.0f;
+        identity.scale = 1.0f;
+        identity.rotation.v[0].array[0] = 1.0f;
+        identity.rotation.v[1].array[1] = 1.0f;
+        identity.rotation.v[2].array[2] = 1.0f;
+        iset = true;
       }
 
-	  return identity;
+	  return &identity;
   }
 };
 #pragma pack(pop)

--- a/components/nif/nif_types.hpp
+++ b/components/nif/nif_types.hpp
@@ -55,26 +55,26 @@ struct Matrix
 
 struct Transformation
 {
-  Vector pos;
-  Matrix rotation;
-  float scale;
-  Vector velocity;
+    Vector pos;
+    Matrix rotation;
+    float scale;
+    Vector velocity;
 
-  static const Transformation* getIdentity()
-  {
-	  static Transformation identity;
-      static bool iset = false;
-	  if (!iset)
-      {
-        identity.scale = 1.0f;
-        identity.rotation.v[0].array[0] = 1.0f;
-        identity.rotation.v[1].array[1] = 1.0f;
-        identity.rotation.v[2].array[2] = 1.0f;
-        iset = true;
-      }
+    static const Transformation* getIdentity()
+    {
+        static Transformation identity;
+        static bool iset = false;
+        if (!iset)
+        {
+            identity.scale = 1.0f;
+            identity.rotation.v[0].array[0] = 1.0f;
+            identity.rotation.v[1].array[1] = 1.0f;
+            identity.rotation.v[2].array[2] = 1.0f;
+            iset = true;
+        }
 
-	  return &identity;
-  }
+        return &identity;
+    }
 };
 #pragma pack(pop)
 

--- a/components/nif/nif_types.hpp
+++ b/components/nif/nif_types.hpp
@@ -59,6 +59,21 @@ struct Transformation
   Matrix rotation;
   float scale;
   Vector velocity;
+
+  static const Transformation* getIdentity()
+  {
+	  static Transformation* identity = NULL;
+	  if (NULL == identity)
+      {
+        identity = new Transformation();
+        identity->scale = 1.0f;
+        identity->rotation.v[0].array[0] = 1.0f;
+        identity->rotation.v[1].array[1] = 1.0f;
+        identity->rotation.v[2].array[2] = 1.0f;
+      }
+
+	  return identity;
+  }
 };
 #pragma pack(pop)
 


### PR DESCRIPTION
Discard the tranformation of the root NiNode when loading nif files

Checked the following interiors:
- Dwemer ruins (the bug was common here before the fix)
- Ancestral tombs (the bug was common here before the fix)
- Daedric shrines
- Caves/grottos
- Dunmer strongholds
- Telvanni, imperial, redoran houses/towers/castles

Also checked exteriors (although it is hard to verify without terrain rendering)
