### PR TITLE
Added missing slash

### DIFF
--- a/apps/launcher/CMakeLists.txt
+++ b/apps/launcher/CMakeLists.txt
@@ -95,5 +95,5 @@ else()
         "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/launcher.qss")
 
     configure_file(${CMAKE_SOURCE_DIR}/files/launcher.cfg
-        "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}launcher.cfg")
+        "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/launcher.cfg")
 endif()


### PR DESCRIPTION
Found this while making the AUR packages. Apparently I deleted a slash from the launcher CMakeLists.txt which prevents the launcher.cfg from being copied to the build dir.
