### PR TITLE
Fix for segfault when doing 'coc "seyda neen"' when animations are enabled.

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -126,6 +126,11 @@ namespace MWRender{
    void Animation::handleShapes(std::vector<Nif::NiTriShapeCopy>* allshapes, Ogre::Entity* creaturemodel, Ogre::SkeletonInstance *skel){
         shapeNumber = 0;
 
+        if (allshapes == NULL || creaturemodel == NULL || skel == NULL)
+        {
+            return;
+        }
+
         std::vector<Nif::NiTriShapeCopy>::iterator allshapesiter;
 	    for(allshapesiter = allshapes->begin(); allshapesiter != allshapes->end(); allshapesiter++)
 


### PR DESCRIPTION
This is a fix for segfault:

==8683== Process terminating with default action of signal 11 (SIGSEGV)
==8683==  Access not within mapped region at address 0x0
==8683==    at 0x59DFE4: MWRender::Animation::handleShapes(std::vector<Nif::NiTriShapeCopy, std::allocator<Nif::NiTriShapeCopy> >_, Ogre::Entity_, Ogre::SkeletonInstance*) (animation.cpp:503)
==8683==    by 0x5A4ECE: MWRender::Actors::update(float) (actors.cpp:134)
==8683==    by 0x5937A9: MWRender::RenderingManager::update(float) (renderingmanager.cpp:168)
==8683==    by 0x629AD6: MWWorld::World::update(float) (world.cpp:705)
==8683==    by 0x68B022: OMW::Engine::frameRenderingQueued(Ogre::FrameEvent const&) (engine.cpp:157)
==8683==    by 0x51F9574: Ogre::Root::_fireFrameRenderingQueued(Ogre::FrameEvent&) (in /usr/lib/libOgreMain.so.1.8.0)
==8683==    by 0x51F964F: Ogre::Root::_fireFrameRenderingQueued() (in /usr/lib/libOgreMain.so.1.8.0)
==8683==    by 0x51F9681: Ogre::Root::_updateAllRenderTargets() (in /usr/lib/libOgreMain.so.1.8.0)
==8683==    by 0x51F98CF: Ogre::Root::renderOneFrame() (in /usr/lib/libOgreMain.so.1.8.0)
==8683==    by 0x51F990C: Ogre::Root::startRendering() (in /usr/lib/libOgreMain.so.1.8.0)
==8683==    by 0x68A669: OMW::Engine::go() (engine.cpp:408)
==8683==    by 0x51CECB: main (main.cpp:254)
==8683==  If you believe this happened as a result of a stack
==8683==  overflow in your program's main thread (unlikely but
==8683==  possible), you can try to increase the size of the
==8683==  main thread stack using the --main-stacksize= flag.
==8683==  The main thread stack size used in this run was 8388608.

when doing 'coc "seyda neen"' when animations are enabled
(Animation::animate member variable is set to 1).
