### PR TITLE
Changed order of plugins.cfg file paths.

### DIFF
--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -28,10 +28,10 @@ ConfigurationManager::ConfigurationManager()
 {
     setupTokensMapping();
 
-    mPluginsCfgPath = mFixedPath.getGlobalPath() / pluginsCfgFile;
+    mPluginsCfgPath = mFixedPath.getLocalPath() / pluginsCfgFile;
     if (!boost::filesystem::is_regular_file(mPluginsCfgPath))
     {
-        mPluginsCfgPath = mFixedPath.getLocalPath() / pluginsCfgFile;
+        mPluginsCfgPath = mFixedPath.getGlobalPath() / pluginsCfgFile;
         if (!boost::filesystem::is_regular_file(mPluginsCfgPath))
         {
             std::cerr << "Failed to find " << pluginsCfgFile << " file!" << std::endl;


### PR DESCRIPTION
Changed order of plugins.cfg file paths - before when plugins.cfg file
was found in global path then it was used as default one. Now the behavoiur
is opposite if plugins.cfg file exists in local path then it is used as
default one.

Requested (and tested) by K1ll:

"[11/05/2012 21:22] [K1ll] well it's just that the priority for the plugins.cfg must
be the other way around
[11/05/2012 21:22] [K1ll] at the moment always the global plugins.cfg in /etc/openmw
is used even if there is one in the same directory as the openmw binary"
