### PR TITLE
Changed the way the launcher exits and polished the error handling code

### DIFF
--- a/apps/launcher/datafilespage.cpp
+++ b/apps/launcher/datafilespage.cpp
@@ -140,7 +140,7 @@ DataFilesPage::DataFilesPage(Files::ConfigurationManager &cfg, QWidget *parent)
 
     createActions();
     setupConfig();
-    setupDataFiles();
+    //setupDataFiles();
 
 }
 
@@ -189,7 +189,7 @@ void DataFilesPage::setupConfig()
 }
 
 
-void DataFilesPage::setupDataFiles()
+bool DataFilesPage::setupDataFiles()
 {
     // We use the Configuration Manager to retrieve the configuration values
     boost::program_options::variables_map variables;
@@ -245,19 +245,13 @@ void DataFilesPage::setupDataFiles()
                 mCfgMgr.processPaths(mDataDirs);
             } else {
                 // Cancel from within the dir selection dialog
-                break;
+                return false;
             }
 
         } else {
             // Cancel
-            break;
+            return false;
         }
-    }
-
-    // Check if cancel was clicked because we can't exit from while loop
-    if (mDataDirs.empty()) {
-        QApplication::exit(1);
-        return;
     }
 
     // Create a file collection for the data dirs
@@ -362,6 +356,7 @@ void DataFilesPage::setupDataFiles()
     }
 
     readConfig();
+    return true;
 }
 
 void DataFilesPage::createActions()
@@ -1076,7 +1071,7 @@ void DataFilesPage::writeConfig(QString profile)
                               Please make sure you have the right permissions and try again.<br>").arg(pathStr));
             msgBox.exec();
 
-            qApp->exit(1);
+            qApp->quit();
             return;
         }
     }
@@ -1093,7 +1088,7 @@ void DataFilesPage::writeConfig(QString profile)
                           Please make sure you have the right permissions and try again.<br>").arg(file.fileName()));
         msgBox.exec();
 
-        qApp->exit(1);
+        qApp->quit();
         return;
     }
 
@@ -1124,7 +1119,7 @@ void DataFilesPage::writeConfig(QString profile)
                           Please make sure you have the right permissions and try again.<br>").arg(file.fileName()));
         msgBox.exec();
 
-        qApp->exit(1);
+        qApp->quit();
         return;
     }
 

--- a/apps/launcher/datafilespage.hpp
+++ b/apps/launcher/datafilespage.hpp
@@ -34,6 +34,7 @@ public:
     ComboBox *mProfilesComboBox;
 
     void writeConfig(QString profile = QString());
+    bool setupDataFiles();
 
 public slots:
     void masterSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
@@ -92,7 +93,6 @@ private:
     void removePlugins(const QModelIndex &index);
     void uncheckPlugins();
     void createActions();
-    void setupDataFiles();
     void setupConfig();
     void readConfig();
     void scrollToSelection();

--- a/apps/launcher/filedialog.cpp
+++ b/apps/launcher/filedialog.cpp
@@ -28,13 +28,13 @@ QString FileDialog::getExistingDirectory(QWidget *parent,
     // create a non-native file dialog
     FileDialog dialog;
     dialog.setFileMode(DirectoryOnly);
-    dialog.setOptions(options & (DontUseNativeDialog | ShowDirsOnly));
+    dialog.setOptions(options |= QFileDialog::DontUseNativeDialog | QFileDialog::ShowDirsOnly | QFileDialog::ReadOnly);
 
     if (!caption.isEmpty())
         dialog.setWindowTitle(caption);
 
     if (!dir.isEmpty())
-    dialog.setDirectory(dir);
+        dialog.setDirectory(dir);
 
     if (dialog.exec() == QDialog::Accepted) {
         return dialog.selectedFiles().value(0);

--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -45,10 +45,6 @@ GraphicsPage::GraphicsPage(Files::ConfigurationManager &cfg, QWidget *parent)
     connect(mRendererComboBox, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(rendererChanged(const QString&)));
 
     createPages();
-    setupConfig();
-    setupOgre();
-
-    readConfig();
 }
 
 void GraphicsPage::createPages()
@@ -78,11 +74,7 @@ void GraphicsPage::createPages()
     mDisplayStackedWidget->addWidget(main);
 }
 
-void GraphicsPage::setupConfig()
-{
-}
-
-void GraphicsPage::setupOgre()
+bool GraphicsPage::setupOgre()
 {
     QString pluginCfg = mCfgMgr.getPluginsConfigPath().string().c_str();
     QFile file(pluginCfg);
@@ -113,9 +105,7 @@ void GraphicsPage::setupOgre()
         msgBox.exec();
 
         qCritical("Error creating Ogre::Root, the error reported was:\n %s", qPrintable(ogreError));
-
-        qApp->exit(1);
-        return;
+        return false;
     }
 
 	#ifdef ENABLE_PLUGIN_GL
@@ -165,8 +155,7 @@ void GraphicsPage::setupOgre()
         Please make sure the plugins.cfg file exists and contains a valid rendering plugin.<br>"));
         msgBox.exec();
 
-        qApp->exit(1);
-        return;
+        return false;
     }
 
     // Now fill the GUI elements
@@ -174,6 +163,9 @@ void GraphicsPage::setupOgre()
     mResolutionComboBox->clear();
     mAntiAliasingComboBox->addItems(getAvailableOptions(QString("FSAA"), mSelectedRenderSystem));
     mResolutionComboBox->addItems(getAvailableOptions(QString("Video Mode"), mSelectedRenderSystem));
+
+    readConfig();
+    return true;
 }
 
 void GraphicsPage::readConfig()

--- a/apps/launcher/graphicspage.hpp
+++ b/apps/launcher/graphicspage.hpp
@@ -30,6 +30,7 @@ class GraphicsPage : public QWidget
 public:
     GraphicsPage(Files::ConfigurationManager &cfg, QWidget *parent = 0);
 
+    bool setupOgre();
     void writeConfig();
 
 public slots:
@@ -62,8 +63,6 @@ private:
     QStringList getAvailableResolutions(Ogre::RenderSystem *renderer);
 
     void createPages();
-    void setupConfig();
-    void setupOgre();
     void readConfig();
 };
 

--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -1,7 +1,6 @@
 #include <QApplication>
 #include <QDir>
 #include <QFile>
-#include <QtDebug>
 
 #include "maindialog.hpp"
 
@@ -32,9 +31,13 @@ int main(int argc, char *argv[])
     QDir::setCurrent(dir.absolutePath());
 
     MainDialog mainWin;
-    mainWin.show();
 
-    return app.exec();
+    if (mainWin.setup()) {
 
+        mainWin.show();
+        return app.exec();
+    }
+
+    return 0;
 }
 

--- a/apps/launcher/maindialog.hpp
+++ b/apps/launcher/maindialog.hpp
@@ -28,6 +28,7 @@ public slots:
     void changePage(QListWidgetItem *current, QListWidgetItem *previous);
     void play();
     void profileChanged(int index);
+    bool setup();
 
 private:
     void createIcons();


### PR DESCRIPTION
Ok, this should fix the launcher not quitting when an error occurred, turns out the main event loop wasn't always started when QApplication::exit() was called. I also changed it to QApplication::quit() as GUI applications should only return an error code when something goes wrong internally, not after displaying a warning message.
