### PR TITLE
Fix an abort at shutdown

### DIFF
--- a/components/esm/esm_reader.cpp
+++ b/components/esm/esm_reader.cpp
@@ -107,15 +107,15 @@ void ESMReader::open(Ogre::DataStreamPtr _esm, const std::string &name)
 
 void ESMReader::open(const std::string &file)
 {
-    std::ifstream *stream = new std::ifstream(file.c_str(), std::ios_base::binary);
-    //  Ogre will delete the stream for us
+    std::ifstream *stream = OGRE_NEW_T(std::ifstream, Ogre::MEMCATEGORY_GENERAL)(file.c_str(), std::ios_base::binary);
+    // Ogre will delete the stream for us
     open(Ogre::DataStreamPtr(new Ogre::FileStreamDataStream(stream)), file);
 }
 
 void ESMReader::openRaw(const std::string &file)
 {
-    std::ifstream *stream = new std::ifstream(file.c_str(), std::ios_base::binary);
-    //  Ogre will delete the stream for us
+    std::ifstream *stream = OGRE_NEW_T(std::ifstream, Ogre::MEMCATEGORY_GENERAL)(file.c_str(), std::ios_base::binary);
+    // Ogre will delete the stream for us
     openRaw(Ogre::DataStreamPtr(new Ogre::FileStreamDataStream(stream)), file);
 }
 


### PR DESCRIPTION
Ogre uses a special method to delete the stream object, so it needs to be
allocated properly.
