### PR TITLE
Fixes #313: openmw without a ~/.config/openmw folder segfault.

### DIFF
--- a/components/files/configurationmanager.cpp
+++ b/components/files/configurationmanager.cpp
@@ -27,6 +27,8 @@ ConfigurationManager::ConfigurationManager()
 {
     setupTokensMapping();
 
+    boost::filesystem::create_directories(mFixedPath.getUserPath());
+
     mPluginsCfgPath = mFixedPath.getLocalPath() / pluginsCfgFile;
     if (!boost::filesystem::is_regular_file(mPluginsCfgPath))
     {


### PR DESCRIPTION
Added creation of $HOME/.config/openmw directory.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
