### PR TITLE
Workaround to let main loop know Ogre::Root's mQueuedEnd value

### DIFF
--- a/libs/openengine/ogre/renderer.hpp
+++ b/libs/openengine/ogre/renderer.hpp
@@ -27,9 +27,15 @@
 #include "OgreTexture.h"
 #include <OgreWindowEventUtilities.h>
 
+#if defined(__APPLE__) && !defined(__LP64__)  
+#include <OgreRoot.h>
+#endif
+
 namespace Ogre
 {
+#if !defined(__APPLE__) || defined(__LP64__)
     class Root;
+#endif
     class RenderWindow;
     class SceneManager;
     class Camera;
@@ -48,10 +54,25 @@ namespace OEngine
             std::string fsaa;
         };
 
+#if defined(__APPLE__) && !defined(__LP64__)
+        class CustomRoot : public Ogre::Root {
+        public:
+            bool isQueuedEnd() const;
+
+            CustomRoot(const Ogre::String& pluginFileName = "plugins.cfg", 
+                    const Ogre::String& configFileName = "ogre.cfg", 
+                    const Ogre::String& logFileName = "Ogre.log");
+        };
+#endif
+
         class Fader;
         class OgreRenderer
         {
+#if defined(__APPLE__) && !defined(__LP64__)
+            CustomRoot *mRoot;
+#else
             Ogre::Root *mRoot;
+#endif
             Ogre::RenderWindow *mWindow;
             Ogre::SceneManager *mScene;
             Ogre::Camera *mCamera;


### PR DESCRIPTION
This change is needed because of recent changes in exit handling.

I'm not sure how to do it with less #ifdef clutter, only way I see is define CustomRoot completely in .cpp file and static_cast mRoot to CustomRoot at runtime in main loop. But it's not very nice anyway =\
