### PR TITLE
Use debug dlls when debugging in vs2010 (try 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,13 +257,15 @@ if (APPLE)
         "${APP_BUNDLE_DIR}/Contents/Resources/OpenMW.icns" COPYONLY)
 endif (APPLE)
 
+# Set up DEBUG define
+set_directory_properties(PROPERTIES COMPILE_DEFINITIONS_DEBUG DEBUG=1)
 
 # Set up Ogre plugin folder & debug suffix
-# Ogre on OS X doesn't use "_d" suffix (see Ogre's CMakeLists.txt)
-if (DEFINED CMAKE_BUILD_TYPE AND CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT APPLE)
-	add_definitions(-DOGRE_PLUGIN_DEBUG_SUFFIX="_d")
-else()
+if (APPLE)
+	# Ogre on OS X doesn't use "_d" suffix (see Ogre's CMakeLists.txt)
 	add_definitions(-DOGRE_PLUGIN_DEBUG_SUFFIX="")
+else ()
+	add_definitions(-DOGRE_PLUGIN_DEBUG_SUFFIX="_d")
 endif()
 
 add_definitions(-DOGRE_PLUGIN_DIR_REL="${OGRE_PLUGIN_DIR_REL}")

--- a/components/files/ogreplugin.cpp
+++ b/components/files/ogreplugin.cpp
@@ -6,7 +6,11 @@
 namespace Files {
 
 bool loadOgrePlugin(const std::string &pluginDir, std::string pluginName, Ogre::Root &ogreRoot) {
+    // Append plugin suffix if debugging.
+#if defined(DEBUG)
 	pluginName = pluginName + OGRE_PLUGIN_DEBUG_SUFFIX;
+#endif
+
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
 	std::ostringstream verStream;
 	verStream << "." << OGRE_VERSION_MAJOR << "." << OGRE_VERSION_MINOR << "." << OGRE_VERSION_PATCH;


### PR DESCRIPTION
Using the Debug build in vs2010 is not working because the debug dlls are
not loaded when debugging. The reason they are not loaded is that
CMAKE_BUILD_TYPE is not defined when doing multiple builds. This in turns
causes OGRE_PLUGIN_DEBUG_SUFFIX not to be set. This patch makes sure that
OGRE_PLUGIN_DEBUG_SUFFIX is always set but only used when debugging.

It also defines DEBUG to make it easier turn things on and off when
debugging.

There are still other bugs that have broken Debug mode in vs2010 but those
will be addressed in other patches.
