### PR TITLE
Do not define OIS_DYNAMIC_LIB in ICSPrerequisites.h

### DIFF
--- a/extern/oics/ICSPrerequisites.h
+++ b/extern/oics/ICSPrerequisites.h
@@ -39,7 +39,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "tinyxml.h"
 
-#define OIS_DYNAMIC_LIB
 #include <OIS.h>
 #include <OISMouse.h>
 #include <OISKeyboard.h>


### PR DESCRIPTION
Fixes http://bugs.openmw.org/issues/381
