### PR TITLE
fix std::runtime_error compile error 

### DIFF
--- a/components/settings/settings.cpp
+++ b/components/settings/settings.cpp
@@ -1,6 +1,7 @@
 #include "settings.hpp"
 
 #include <fstream>
+#include <stdexcept>
 
 #include <OgreResourceGroupManager.h>
 #include <OgreStringConverter.h>


### PR DESCRIPTION
Fix following error:
[ 11%] Building CXX object
components/CMakeFiles/components.dir/nifoverrides/nifoverrides.cpp.o
/home/edmondo/src/openmw/components/settings/settings.cpp: In static
member function ‘static const std::string
Settings::Manager::getString(const std::string&, const std::string&)’:
/home/edmondo/src/openmw/components/settings/settings.cpp:82:15: error:
‘runtime_error’ is not a member of ‘std’
make[2]: ***
[components/CMakeFiles/components.dir/settings/settings.cpp.o] Error 1
