### PR TITLE
Be explicit about boolean conversion

### DIFF
--- a/apps/esmtool/esmtool.cpp
+++ b/apps/esmtool/esmtool.cpp
@@ -148,8 +148,8 @@ int main(int argc, char**argv)
       return 0;
     }
 
-  bool quiet = info.quiet_given;
-  bool loadCells = info.loadcells_given;
+  bool quiet = info.quiet_given > 0;
+  bool loadCells = info.loadcells_given > 0;
 
   esm.open(filename);
 

--- a/apps/mwiniimporter/main.cpp
+++ b/apps/mwiniimporter/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
     }
 
     MwIniImporter importer;
-    importer.setVerbose(vm.count("verbose"));
+    importer.setVerbose(vm.count("verbose") > 0);
 
     MwIniImporter::multistrmap ini = importer.loadIniFile(iniFile);
     MwIniImporter::multistrmap cfg = importer.loadCfgFile(cfgFile);

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -306,25 +306,25 @@ namespace MWGui
         if      (item.getTypeName() == typeid(ESM::Weapon).name())
             return services & ESM::NPC::Weapon;
         else if (item.getTypeName() == typeid(ESM::Armor).name())
-            return services & ESM::NPC::Armor;
+            return (services & ESM::NPC::Armor) > 0;
         else if (item.getTypeName() == typeid(ESM::Clothing).name())
-            return services & ESM::NPC::Clothing;
+            return (services & ESM::NPC::Clothing) > 0;
         else if (item.getTypeName() == typeid(ESM::Book).name())
-            return services & ESM::NPC::Books;
+            return (services & ESM::NPC::Books) > 0;
         else if (item.getTypeName() == typeid(ESM::Ingredient).name())
-            return services & ESM::NPC::Ingredients;
+            return (services & ESM::NPC::Ingredients) > 0;
         else if (item.getTypeName() == typeid(ESM::Tool).name())
-            return services & ESM::NPC::Picks;
+            return (services & ESM::NPC::Picks) > 0;
         else if (item.getTypeName() == typeid(ESM::Probe).name())
-            return services & ESM::NPC::Probes;
+            return (services & ESM::NPC::Probes) > 0;
         else if (item.getTypeName() == typeid(ESM::Light).name())
-            return services & ESM::NPC::Lights;
+            return (services & ESM::NPC::Lights) > 0;
         else if (item.getTypeName() == typeid(ESM::Apparatus).name())
-            return services & ESM::NPC::Apparatus;
+            return (services & ESM::NPC::Apparatus) > 0;
         else if (item.getTypeName() == typeid(ESM::Repair).name())
-            return services & ESM::NPC::RepairItem;
+            return (services & ESM::NPC::RepairItem) > 0;
         else if (item.getTypeName() == typeid(ESM::Miscellaneous).name())
-            return services & ESM::NPC::Misc;
+            return (services & ESM::NPC::Misc) > 0;
 
         return false;
     }

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -300,10 +300,14 @@ void WindowManager::updateVisible()
             int eff = mShown & mAllowed;
 
             // Show the windows we want
-            mMap            ->setVisible(eff & GW_Map);
-            mStatsWindow    ->setVisible(eff & GW_Stats);
-            mInventoryWindow->setVisible(eff & GW_Inventory);
-            mSpellWindow    ->setVisible(eff & GW_Magic);
+            bool showMap = (eff & GW_Map) > 0;
+            bool showStatsWindow = (eff & GW_Stats) > 0;
+            bool showInventoryWindow = (eff & GW_Inventory) > 0;
+            bool showSpellWindow = (eff & GW_Magic) > 0;
+            mMap->setVisible(showMap);
+            mStatsWindow->setVisible(showStatsWindow);
+            mInventoryWindow->setVisible(showInventoryWindow);
+            mSpellWindow->setVisible(showSpellWindow);
             break;
         }
         case GM_Container:
@@ -791,7 +795,7 @@ MWGui::Console* WindowManager::getConsole() { return mConsole; }
 
 bool WindowManager::isAllowed (GuiWindow wnd) const
 {
-    return mAllowed & wnd;
+    return (mAllowed & wnd) > 0;
 }
 
 void WindowManager::allow (GuiWindow wnd)

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -29,7 +29,7 @@ void MWMechanics::NpcStats::setDrawState (DrawState_ state)
 
 bool MWMechanics::NpcStats::getMovementFlag (Flag flag) const
 {
-    return mMovementFlags & flag;
+    return (mMovementFlags & flag) > 0;
 }
 
 void MWMechanics::NpcStats::setMovementFlag (Flag flag, bool state)

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -140,7 +140,7 @@ namespace MWWorld
         const ESM::Position& pos,
         bool adjustPlayerPos)
     {
-        bool hasWater = cell->cell->data.flags & cell->cell->HasWater;
+        bool hasWater = (cell->cell->data.flags & cell->cell->HasWater) > 0;
         mPhysics->setCurrentWater(hasWater, cell->cell->water);
 
         MWBase::World *world = MWBase::Environment::get().getWorld();

--- a/libs/openengine/bullet/physic.cpp
+++ b/libs/openengine/bullet/physic.cpp
@@ -210,7 +210,7 @@ namespace Physic
             createDebugRendering();
         }
         mDebugDrawer->setDebugMode(mode);
-        mDebugActive = mode;
+        mDebugActive = (mode > 0);
     }
 
     bool  PhysicEngine::toggleDebugRendering()


### PR DESCRIPTION
If you cast an int to a boolean implicitly in vs2010, then you get warning
C4800. This changes all such occurrences to be explicit by using the greater
than operator.
