### PR TITLE
make it statically compilable

### DIFF
--- a/libs/openengine/ogre/renderer.cpp
+++ b/libs/openengine/ogre/renderer.cpp
@@ -78,7 +78,7 @@ void OgreRenderer::start()
 #endif
 }
 
-bool OgreRenderer::loadPlugins() const
+bool OgreRenderer::loadPlugins() 
 {
     #ifdef ENABLE_PLUGIN_GL
     mGLPlugin = new Ogre::GLPlugin();

--- a/libs/openengine/ogre/renderer.hpp
+++ b/libs/openengine/ogre/renderer.hpp
@@ -151,7 +151,7 @@ namespace OEngine
             /// Start the main rendering loop
             void start();
 
-            bool loadPlugins() const;
+            bool loadPlugins() ;
 
             void update(float dt);
 


### PR DESCRIPTION
This should correct the 'blocker' of statically compiling for:
http://bugs.openmw.org/issues/373

The memory leak is another issue. However, in reviewing the documentation on the root object, the unload and uninstall are done automatically when Ogre shuts down.

source:
http://www.ogre3d.org/docs/api/html/classOgre_1_1Root.html#a23417d6cbe7aeeafcc6a1a146a5e7b95

We can always do it manually, should be trivial to iterate over the list provided by mRoot->getInstalledPlugins() 
