### PR TITLE
fix ‘runtime_error’ is not a member of ‘std’

### DIFF
--- a/libs/openengine/ogre/selectionbuffer.cpp
+++ b/libs/openengine/ogre/selectionbuffer.cpp
@@ -4,6 +4,7 @@
 #include <OgreRenderTexture.h>
 #include <OgreSubEntity.h>
 #include <OgreEntity.h>
+#include <stdexcept>
 
 #include <extern/shiny/Main/Factory.hpp>
 


### PR DESCRIPTION
Please pull.
It fixes a compile error on gentoo with gcc 4.5
