### PR TITLE
Disable warning 4800 for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,6 +513,7 @@ if (WIN32)
         4309 # Variable overflow, trying to store 128 in a signed char for example
         4355 # Using 'this' in member initialization list
         4701 # Potentially uninitialized local variable used
+		4800 # Boolean optimization warning, e.g. myBool = (myInt != 0) instead of myBool = myInt
         )
 
     foreach(d ${WARNINGS_DISABLE})
@@ -524,6 +525,7 @@ if (WIN32)
 		set_target_properties(omwlauncher PROPERTIES COMPILE_FLAGS ${WARNINGS})
 	endif (BUILD_LAUNCHER)
     set_target_properties(openmw PROPERTIES COMPILE_FLAGS ${WARNINGS})
+	set_target_properties(esmtool PROPERTIES COMPILE_FLAGS ${WARNINGS})
   endif(MSVC)
 
   # Same for MinGW


### PR DESCRIPTION
Visual Studio 2010 complains about constructs such as:

int myInt = 1;
bool myBool = myInt;

Which are fine with most compilers. It would instead like:

int myInt = 1;
bool myBool = (myInt != 0);

Warning 4800 is just an optimization warning and is therefore safe to
disable. This patch disables warning 4800.
