### PR TITLE
Issue #423: Wrong usage of "Version"

### DIFF
--- a/files/openmw.desktop
+++ b/files/openmw.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Version=${OPENMW_VERSION}
 Type=Application
 Name=OpenMW Launcher
 GenericName=Role Playing Game


### PR DESCRIPTION
Remove "Version" line from openmw.desktop file (according to
http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
it's not required).

Fixes #423

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
