### PR TITLE
Fixed segfault when going to previous page in Journal

### DIFF
--- a/apps/openmw/mwgui/journalwindow.cpp
+++ b/apps/openmw/mwgui/journalwindow.cpp
@@ -85,6 +85,7 @@ MWGui::JournalWindow::JournalWindow (MWBase::WindowManager& parWindowManager)
     : WindowBase("openmw_journal.layout", parWindowManager)
     , mLastPos(0)
     , mVisible(false)
+    , mPageNumber(0)
 {
     //setCoord(0,0,498, 342);
     center();


### PR DESCRIPTION
The int mPageNumber was uninitialized which led to attempts at reading beyond mLeftPages' end when calling MWGui::JournalWindow::notifyPrevPage. This resulted in a crash via segfault.
