### PR TITLE
Fix for Bug #437: Stop animations when paused and capitalized tooltips

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -101,7 +101,8 @@ bool OMW::Engine::frameRenderingQueued (const Ogre::FrameEvent& evt)
             MWBase::Environment::get().getWorld()->doPhysics (movement, mEnvironment.getFrameDuration());
 
         // update world
-        MWBase::Environment::get().getWorld()->update (evt.timeSinceLastFrame);
+        if (!MWBase::Environment::get().getWindowManager()->isGuiMode())
+            MWBase::Environment::get().getWorld()->update (evt.timeSinceLastFrame);
 
         // update GUI
         Ogre::RenderWindow* window = mOgre->getWindow();

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -364,6 +364,9 @@ IntSize ToolTips::createToolTip(const MWGui::ToolTipInfo& info)
     if (text.size() > 0 && text[0] == '\n')
         text.erase(0, 1);
 
+    if(caption.size() > 0 && isalnum(caption[0]))
+        caption[0] = toupper(caption[0]);
+
     const ESM::Enchantment* enchant = 0;
     const ESMS::ESMStore& store = MWBase::Environment::get().getWorld()->getStore();
     if (info.enchant != "")


### PR DESCRIPTION
I've added code to engine.cpp to check if we're in gui mode or not before calling World->update(), this seems to work for NPC death and light animations, not sure about texture ones though but my code in the interior-doors branch in World->update() which rotates the doors works fine with this fix too.
I also added a line to ToolTips->createToolTip to capitalize the first letter of the tooltip caption, this is kind of a hacky way to do it but I don't think it would affect the game (other than fixing items with no capitalization)
