### PR TITLE
Fix for Bug #368 "adjustScale and adjustRotation are not applied consistency"

### DIFF
--- a/apps/openmw/mwclass/activator.cpp
+++ b/apps/openmw/mwclass/activator.cpp
@@ -30,9 +30,8 @@ namespace MWClass
     void Activator::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Activator::getModel(const MWWorld::Ptr &ptr) const
@@ -94,7 +93,7 @@ namespace MWClass
 
         return info;
     }
-
+    
     MWWorld::Ptr
     Activator::copyToCellImpl(const MWWorld::Ptr &ptr, MWWorld::CellStore &cell) const
     {

--- a/apps/openmw/mwclass/apparatus.cpp
+++ b/apps/openmw/mwclass/apparatus.cpp
@@ -33,9 +33,8 @@ namespace MWClass
     void Apparatus::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Apparatus::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/armor.cpp
+++ b/apps/openmw/mwclass/armor.cpp
@@ -36,9 +36,8 @@ namespace MWClass
     void Armor::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Armor::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/book.cpp
+++ b/apps/openmw/mwclass/book.cpp
@@ -32,9 +32,8 @@ namespace MWClass
     void Book::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Book::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/clothing.cpp
+++ b/apps/openmw/mwclass/clothing.cpp
@@ -34,9 +34,8 @@ namespace MWClass
     void Clothing::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Clothing::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/container.cpp
+++ b/apps/openmw/mwclass/container.cpp
@@ -65,9 +65,8 @@ namespace MWClass
     void Container::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Container::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/creature.cpp
+++ b/apps/openmw/mwclass/creature.cpp
@@ -94,9 +94,8 @@ namespace MWClass
     void Creature::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()){
-            physics.insertActorPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addActor(ptr);
         MWBase::Environment::get().getMechanicsManager()->addActor (ptr);
     }
 

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -35,9 +35,8 @@ namespace MWClass
     void Door::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Door::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/ingredient.cpp
+++ b/apps/openmw/mwclass/ingredient.cpp
@@ -41,9 +41,8 @@ namespace MWClass
     void Ingredient::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Ingredient::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -53,12 +53,11 @@ namespace MWClass
 
         const std::string &model = ref->base->mModel;
 
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, "meshes\\" + model);
-        }
-        if (!ref->base->mSound.empty()) {
+        if(!model.empty())
+            physics.addObject(ptr);
+        
+        if (!ref->base->mSound.empty())
             MWBase::Environment::get().getSoundManager()->playSound3D(ptr, ref->base->mSound, 1.0, 1.0, MWBase::SoundManager::Play_Loop);
-        }
     }
 
     std::string Light::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/lockpick.cpp
+++ b/apps/openmw/mwclass/lockpick.cpp
@@ -34,9 +34,8 @@ namespace MWClass
     void Lockpick::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Lockpick::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/misc.cpp
+++ b/apps/openmw/mwclass/misc.cpp
@@ -37,9 +37,8 @@ namespace MWClass
     void Miscellaneous::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Miscellaneous::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -138,7 +138,7 @@ namespace MWClass
 
     void Npc::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
-        physics.insertActorPhysics(ptr, getModel(ptr));
+        physics.addActor(ptr);
         MWBase::Environment::get().getMechanicsManager()->addActor(ptr);
     }
 

--- a/apps/openmw/mwclass/potion.cpp
+++ b/apps/openmw/mwclass/potion.cpp
@@ -34,9 +34,8 @@ namespace MWClass
     void Potion::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Potion::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/probe.cpp
+++ b/apps/openmw/mwclass/probe.cpp
@@ -34,9 +34,8 @@ namespace MWClass
     void Probe::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Probe::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/repair.cpp
+++ b/apps/openmw/mwclass/repair.cpp
@@ -32,9 +32,8 @@ namespace MWClass
     void Repair::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Repair::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/static.cpp
+++ b/apps/openmw/mwclass/static.cpp
@@ -24,9 +24,8 @@ namespace MWClass
     void Static::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
     
     std::string Static::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwclass/weapon.cpp
+++ b/apps/openmw/mwclass/weapon.cpp
@@ -34,9 +34,8 @@ namespace MWClass
     void Weapon::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const
     {
         const std::string model = getModel(ptr);
-        if(!model.empty()) {
-            physics.insertObjectPhysics(ptr, model);
-        }
+        if(!model.empty())
+            physics.addObject(ptr);
     }
 
     std::string Weapon::getModel(const MWWorld::Ptr &ptr) const

--- a/apps/openmw/mwrender/player.hpp
+++ b/apps/openmw/mwrender/player.hpp
@@ -48,16 +48,6 @@ namespace MWRender
         /// Updates sound manager listener data
         void updateListener();
 
-        void rotateCamera(const Ogre::Vector3 &rot, bool adjust);
-
-        float getYaw();
-        void setYaw(float angle);
-
-        float getPitch();
-        void setPitch(float angle);
-
-        void compensateYaw(float diff);
-
         void setLowHeight(bool low = true);
 
     public:
@@ -69,7 +59,17 @@ namespace MWRender
         /// \param rot Rotation angles in radians
         /// \return true if player object needs to bo rotated physically
         bool rotate(const Ogre::Vector3 &rot, bool adjust);
+        
+        void rotateCamera(const Ogre::Vector3 &rot, bool adjust);
 
+        float getYaw();
+        void setYaw(float angle);
+
+        float getPitch();
+        void setPitch(float angle);
+
+        void compensateYaw(float diff);
+        
         std::string getHandle() const;
 
         /// Attach camera to object

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -237,8 +237,8 @@ void RenderingManager::addObject (const MWWorld::Ptr& ptr){
     const MWWorld::Class& class_ =
             MWWorld::Class::get (ptr);
     class_.insertObjectRendering(ptr, *this);
-
 }
+
 void RenderingManager::removeObject (const MWWorld::Ptr& ptr)
 {
     if (!mObjects.deleteObject (ptr))

--- a/apps/openmw/mwworld/physicssystem.hpp
+++ b/apps/openmw/mwworld/physicssystem.hpp
@@ -20,11 +20,9 @@ namespace MWWorld
             std::vector< std::pair<std::string, Ogre::Vector3> > doPhysicsFixed (const std::vector<std::pair<std::string, Ogre::Vector3> >& actors);
             ///< do physics with fixed timestep - Usage: first call doPhysics with frame dt, then call doPhysicsFixed as often as time steps have passed
 
-            void addObject (const std::string& handle, const std::string& mesh,
-                const Ogre::Quaternion& rotation, float scale, const Ogre::Vector3& position);
+            void addObject (const MWWorld::Ptr& ptr);
 
-            void addActor (const std::string& handle, const std::string& mesh,
-                const Ogre::Vector3& position, float scale, const Ogre::Quaternion& rotation);
+            void addActor (const MWWorld::Ptr& ptr);
 
             void addHeightField (float* heights,
                 int x, int y, float yoffset,
@@ -32,13 +30,14 @@ namespace MWWorld
 
             void removeHeightField (int x, int y);
 
+            // have to keep this as handle for now as unloadcell only knows scenenode names
             void removeObject (const std::string& handle);
 
-            void moveObject (const std::string& handle, Ogre::SceneNode* node);
+            void moveObject (const MWWorld::Ptr& ptr);
 
-            void rotateObject (const std::string& handle, Ogre::SceneNode* node);
+            void rotateObject (const MWWorld::Ptr& ptr);
 
-            void scaleObject (const std::string& handle, Ogre::SceneNode* node);
+            void scaleObject (const MWWorld::Ptr& ptr);
 
             bool toggleCollisionMode();
             
@@ -59,10 +58,6 @@ namespace MWWorld
 
             std::pair<bool, Ogre::Vector3> castRay(float mouseX, float mouseY);
             ///< cast ray from the mouse, return true if it hit something and the first result (in OGRE coordinates)
-
-            void insertObjectPhysics(const MWWorld::Ptr& ptr, std::string model);
-
-            void insertActorPhysics(const MWWorld::Ptr&, std::string model);
 
             OEngine::Physic::PhysicEngine* getEngine();
 

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -41,6 +41,8 @@ namespace
                     {
                         rendering.addObject(ptr);
                         class_.insertObject(ptr, physics);
+                        MWBase::Environment::get().getWorld()->rotateObject(ptr, 0, 0, 0, true);
+                        MWBase::Environment::get().getWorld()->scaleObject(ptr, ptr.getCellRef().mScale);
                     }
                     catch (const std::exception& e)
                     {
@@ -417,6 +419,8 @@ namespace MWWorld
     {
         mRendering.addObject(ptr);
         MWWorld::Class::get(ptr).insertObject(ptr, *mPhysics);
+        MWBase::Environment::get().getWorld()->rotateObject(ptr, 0, 0, 0, true);
+        MWBase::Environment::get().getWorld()->scaleObject(ptr, ptr.getCellRef().mScale);
     }
 
     void Scene::removeObjectFromScene (const Ptr& ptr)

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -189,11 +189,8 @@ namespace MWWorld
         mPlayer = new MWWorld::Player (mStore.npcs.find ("player"), *this);
         mRendering->attachCameraTo(mPlayer->getPlayer());
 
-        std::string playerCollisionFile = "meshes\\base_anim.nif";    //This is used to make a collision shape for our player
-                                                                      //We will need to support the 1st person file too in the future
         mPhysics->addActor(mPlayer->getPlayer());
-//        mPhysics->addActor (mPlayer->getPlayer().getRefData().getHandle(), playerCollisionFile, Ogre::Vector3 (0, 0, 0), 1, Ogre::Quaternion::ZERO);
-
+        
         // global variables
         mGlobalVariables = new Globals (mStore);
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -191,7 +191,8 @@ namespace MWWorld
 
         std::string playerCollisionFile = "meshes\\base_anim.nif";    //This is used to make a collision shape for our player
                                                                       //We will need to support the 1st person file too in the future
-        mPhysics->addActor (mPlayer->getPlayer().getRefData().getHandle(), playerCollisionFile, Ogre::Vector3 (0, 0, 0), 1, Ogre::Quaternion::ZERO);
+        mPhysics->addActor(mPlayer->getPlayer());
+//        mPhysics->addActor (mPlayer->getPlayer().getRefData().getHandle(), playerCollisionFile, Ogre::Vector3 (0, 0, 0), 1, Ogre::Quaternion::ZERO);
 
         // global variables
         mGlobalVariables = new Globals (mStore);
@@ -582,39 +583,48 @@ namespace MWWorld
         CellStore *currCell = ptr.getCell();
         bool isPlayer = ptr == mPlayer->getPlayer();
         bool haveToMove = mWorldScene->isCellActive(*currCell) || isPlayer;
-        if (*currCell != newCell) {
-            if (isPlayer) {
-                if (!newCell.isExterior()) {
+        if (*currCell != newCell)
+        {
+            if (isPlayer)
+                if (!newCell.isExterior())
                     changeToInteriorCell(toLower(newCell.cell->mName), pos);
-                } else {
+                else
+                {
                     int cellX = newCell.cell->mData.mX;
                     int cellY = newCell.cell->mData.mY;
                     mWorldScene->changeCell(cellX, cellY, pos, false);
                 }
-            } else {
-                if (!mWorldScene->isCellActive(*currCell)) {
+            else {
+                if (!mWorldScene->isCellActive(*currCell))
                     copyObjectToCell(ptr, newCell, pos);
-                } else if (!mWorldScene->isCellActive(newCell)) {
+                else if (!mWorldScene->isCellActive(newCell))
+                {
                     MWWorld::Class::get(ptr).copyToCell(ptr, newCell);
                     mWorldScene->removeObjectFromScene(ptr);
                     mLocalScripts.remove(ptr);
                     haveToMove = false;
-                } else {
+                }
+                else
+                {
                     MWWorld::Ptr copy =
                         MWWorld::Class::get(ptr).copyToCell(ptr, newCell);
 
                     mRendering->moveObjectToCell(copy, vec, currCell);
 
-                    if (MWWorld::Class::get(ptr).isActor()) {
+                    if (MWWorld::Class::get(ptr).isActor())
+                    {
                         MWBase::MechanicsManager *mechMgr =
                             MWBase::Environment::get().getMechanicsManager();
 
                         mechMgr->removeActor(ptr);
                         mechMgr->addActor(copy);
-                    } else {
+                    }
+                    else
+                    {
                         std::string script =
                             MWWorld::Class::get(ptr).getScript(ptr);
-                        if (!script.empty()) {
+                        if (!script.empty())
+                        {
                             mLocalScripts.remove(ptr);
                             mLocalScripts.add(script, copy);
                         }
@@ -623,9 +633,10 @@ namespace MWWorld
                 ptr.getRefData().setCount(0);
             }
         }
-        if (haveToMove) {
+        if (haveToMove)
+        {
             mRendering->moveObject(ptr, vec);
-            mPhysics->moveObject (ptr.getRefData().getHandle(), ptr.getRefData().getBaseNode());
+            mPhysics->moveObject (ptr);
         }
     }
 
@@ -657,7 +668,7 @@ namespace MWWorld
         ptr.getCellRef().mScale = scale;
         //scale = scale/ptr.getRefData().getBaseNode()->getScale().x;
         ptr.getRefData().getBaseNode()->setScale(scale,scale,scale);
-        mPhysics->scaleObject( ptr.getRefData().getHandle(), ptr.getRefData().getBaseNode());
+        mPhysics->scaleObject(ptr);
     }
 
     void World::rotateObject (const Ptr& ptr,float x,float y,float z, bool adjust)
@@ -673,10 +684,7 @@ namespace MWWorld
 
 
             if (ptr.getRefData().getBaseNode() != 0) {
-                mPhysics->rotateObject(
-                    ptr.getRefData().getHandle(),
-                    ptr.getRefData().getBaseNode()
-                );
+                mPhysics->rotateObject(ptr);
             }
         }
 


### PR DESCRIPTION
I've rearranged the code so that the scaleObject/rotateObject functions in MWWorld work according to your post on the forum, on cell load the objects now get adjusted properly so it should be about the same as what you intended (I haven't tried creating objects yet though).
I also fixed the rotateObject function in RenderingManager so the proper rotation gets stored in the objects RefData as previously it could go to angles >360. I also added a fix so the players proper pitch/yaw get stored too (makes getting them from outside MWRender much easier)
Lastly I've changed the functions in PhysicsSystem to take MWWorld::Ptr instead of strings/floats/vectors/etc, much cleaner imo.
