### PR TITLE
Double spending when bribing bug fixed.

### DIFF
--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -105,9 +105,9 @@ void PersuasionDialog::onPersuade(MyGUI::Widget *sender)
         type = MWBase::MechanicsManager::PT_Bribe1000;
     }
 
+    setVisible(false);
     MWBase::Environment::get().getDialogueManager()->persuade(type);
 
-    setVisible(false);
 }
 
 void PersuasionDialog::open()

--- a/apps/openmw/mwgui/tradewindow.cpp
+++ b/apps/openmw/mwgui/tradewindow.cpp
@@ -132,6 +132,7 @@ namespace MWGui
         }
         if (goldFound)
         {
+            assert(gold.getRefData().getCount() >= -amount);
             gold.getRefData().setCount(gold.getRefData().getCount() + amount);
         }
         else


### PR DESCRIPTION
There was a bug in the persuasion menu.
The persuasion window would not hide and the gold was not updated.

The player was able to keep bribing even when he ran out of gold, at which point the gold amount would go in the negatives.
I got the persuasion window to hide at the proper moment and added an assert to the addOrRemoveGold to complement the case where no gold is found.

I am not sure if the game should call an exception and/or set the gold to zero at that point, but for now double spending will be caught by the assert.
