### PR TITLE
cache results of query for spash screen names

### DIFF
--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -213,22 +213,26 @@ namespace MWGui
 
     void LoadingScreen::changeWallpaper ()
     {
-        std::vector<std::string> splash;
-
-        Ogre::StringVectorPtr resources = Ogre::ResourceGroupManager::getSingleton ().listResourceNames ("General", false);
-        for (Ogre::StringVector::const_iterator it = resources->begin(); it != resources->end(); ++it)
+        if (mResources.isNull ())
         {
-            if (it->size() < 6)
-                continue;
-            std::string start = it->substr(0, 6);
-            boost::to_lower(start);
+            mResources = Ogre::StringVectorPtr (new Ogre::StringVector);
 
-            if (start == "splash")
-                splash.push_back (*it);
+            Ogre::StringVectorPtr resources = Ogre::ResourceGroupManager::getSingleton ().listResourceNames ("General", false);
+            for (Ogre::StringVector::const_iterator it = resources->begin(); it != resources->end(); ++it)
+            {
+                if (it->size() < 6)
+                    continue;
+                std::string start = it->substr(0, 6);
+                boost::to_lower(start);
+
+                if (start == "splash")
+                    mResources->push_back (*it);
+            }
         }
-        if (splash.size())
+
+        if (mResources->size())
         {
-            std::string randomSplash = splash[rand() % splash.size()];
+            std::string randomSplash = mResources->at (rand() % mResources->size());
 
             Ogre::TexturePtr tex = Ogre::TextureManager::getSingleton ().load (randomSplash, "General");
             mBackgroundImage->setImageTexture (randomSplash);

--- a/apps/openmw/mwgui/loadingscreen.hpp
+++ b/apps/openmw/mwgui/loadingscreen.hpp
@@ -42,6 +42,7 @@ namespace MWGui
         Ogre::Rectangle2D* mRectangle;
         Ogre::MaterialPtr mBackgroundMaterial;
 
+        Ogre::StringVectorPtr mResources;
 
         bool mLoadingOn;
 


### PR DESCRIPTION
ResourceGroupManager::listResourceNames returns a list of all resource
accessable which is expensive, this change caches the result of the
processed query so additional splash screen changes are quicker.
