### PR TITLE
overrode MyGUI::DataManager::isDataExist

### DIFF
--- a/libs/openengine/gui/manager.cpp
+++ b/libs/openengine/gui/manager.cpp
@@ -6,6 +6,19 @@
 
 using namespace OEngine::GUI;
 
+/*
+ *  As of MyGUI 3.2.0, MyGUI::OgreDataManager::isDataExist is unnecessarily complex
+ *  this override fixes the resulting performance issue.
+ */
+class FixedOgreDataManager : public MyGUI::OgreDataManager
+{
+public:
+    bool isDataExist(const std::string& _name)
+    {
+        return Ogre::ResourceGroupManager::getSingleton().resourceExistsInAnyGroup (_name);
+    }
+};
+
 void MyGUIManager::setup(Ogre::RenderWindow *wnd, Ogre::SceneManager *mgr, bool logging, const std::string& logDir)
 {
     assert(wnd);
@@ -25,11 +38,18 @@ void MyGUIManager::setup(Ogre::RenderWindow *wnd, Ogre::SceneManager *mgr, bool 
     if(!logDir.empty())
         theLogFile.insert(0, logDir);
 
-    // Set up OGRE platform. We might make this more generic later.
-    mPlatform = new OgrePlatform();
-    LogManager::getInstance().setSTDOutputEnabled(logging);
-    mPlatform->initialise(wnd, mgr, "General", theLogFile);
+    // Set up OGRE platform (bypassing OgrePlatform). We might make this more generic later.
+    mLogManager = new LogManager();
+    mRenderManager = new OgreRenderManager();
+    mDataManager = new FixedOgreDataManager();
 
+    LogManager::getInstance().setSTDOutputEnabled(logging);
+
+    if (!theLogFile.empty())
+        LogManager::getInstance().createDefaultSource(theLogFile);
+
+    mRenderManager->initialise(wnd, mgr);
+    mDataManager->initialise("General");
 
     // Create GUI
     mGui = new Gui();
@@ -40,11 +60,22 @@ void MyGUIManager::shutdown()
 {
     mGui->shutdown ();
     delete mGui;
-    if(mPlatform)
+    if(mRenderManager)
     {
-        mPlatform->shutdown();
-        delete mPlatform;
+        mRenderManager->shutdown();
+        delete mRenderManager;
+        mRenderManager = NULL;
+    }
+    if(mDataManager)
+    {
+        mDataManager->shutdown();
+        delete mDataManager;
+        mDataManager = NULL;
+    }
+    if (mLogManager)
+    {
+        delete mLogManager;
+        mLogManager = NULL;
     }
     mGui = NULL;
-    mPlatform = NULL;
 }

--- a/libs/openengine/gui/manager.hpp
+++ b/libs/openengine/gui/manager.hpp
@@ -3,8 +3,10 @@
 
 namespace MyGUI
 {
-  class OgrePlatform;
   class Gui;
+  class LogManager;
+  class OgreDataManager;
+  class OgreRenderManager;
 }
 
 namespace Ogre
@@ -18,12 +20,15 @@ namespace GUI
 {
     class MyGUIManager
     {
-        MyGUI::OgrePlatform *mPlatform;
         MyGUI::Gui *mGui;
+        MyGUI::LogManager* mLogManager;
+        MyGUI::OgreDataManager* mDataManager;
+        MyGUI::OgreRenderManager* mRenderManager;
         Ogre::SceneManager* mSceneMgr;
 
+
     public:
-        MyGUIManager() : mPlatform(NULL), mGui(NULL) {}
+        MyGUIManager() : mLogManager(NULL), mDataManager(NULL), mRenderManager(NULL),  mGui(NULL) {}
         MyGUIManager(Ogre::RenderWindow *wnd, Ogre::SceneManager *mgr, bool logging=false, const std::string& logDir = std::string(""))
         {
             setup(wnd,mgr,logging, logDir);


### PR DESCRIPTION
Created a override of MyGUI::DataManager::isDataExist to fix a
performance issue with MyGUI startup. This required moving the
functionality of MyGUI::OgrePlatform into OEngine::GUI::MyGUIManager so
that a new version of the MyGUI::DataManager could be created.
