### PR TITLE
NIF file cache

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -326,6 +326,8 @@ void OMW::Engine::go()
     windowSettings.fsaa = (aa.substr(0, 4) == "MSAA") ? aa.substr(5, aa.size()-5) : "0";
     mOgre->createWindow("OpenMW", windowSettings);
 
+	Nif::NIFFile::lock_cache (); // lock NIFFile cache for initializiation...
+
     loadBSA();
 
     // cursor replacer (converts the cursor from the bsa so they can be used by mygui)
@@ -408,6 +410,8 @@ void OMW::Engine::go()
 
     if (!mStartupScript.empty())
         MWBase::Environment::get().getWindowManager()->executeInConsole (mStartupScript);
+
+	Nif::NIFFile::unlock_cache (); // let go now that we are good 2 go...
 
     // Start the main rendering loop
     mOgre->start();

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -172,6 +172,8 @@ namespace MWWorld
 
     void Scene::changeCell (int X, int Y, const ESM::Position& position, bool adjustPlayerPos)
     {
+        Nif::NIFFile::lock_cache ();
+
         mRendering.preCellChange(mCurrentCell);
 
         // remove active
@@ -296,6 +298,8 @@ namespace MWWorld
         mCellChanged = true;
 
         MWBase::Environment::get().getWindowManager ()->loadingDone ();
+
+        Nif::NIFFile::lock_cache ();
     }
 
     //We need the ogre renderer and a scene node.

--- a/components/nif/nif_file.cpp
+++ b/components/nif/nif_file.cpp
@@ -211,14 +211,14 @@ void NiSkinInstance::post(NIFFile *nif)
     }
 }
 
-Ogre::Matrix4 Node::getLocalTransform()
+Ogre::Matrix4 Node::getLocalTransform() const
 {
     Ogre::Matrix4 mat4(Ogre::Matrix4::IDENTITY);
     mat4.makeTransform(trafo.pos, Ogre::Vector3(trafo.scale), Ogre::Quaternion(trafo.rotation));
     return mat4;
 }
 
-Ogre::Matrix4 Node::getWorldTransform()
+Ogre::Matrix4 Node::getWorldTransform() const
 {
     if(parent != NULL)
         return parent->getWorldTransform() * getLocalTransform();

--- a/components/nif/nif_file.cpp
+++ b/components/nif/nif_file.cpp
@@ -38,6 +38,112 @@ using namespace std;
 using namespace Nif;
 using namespace Misc;
 
+int NIFFile::sCacheLockLevel = 0;
+NIFFile::loaded_map NIFFile::sLoadedMap;
+NIFFile::locked_files NIFFile::sLockedFiles;
+
+void NIFFile::lock_cache ()
+{
+	sCacheLockLevel++;
+}
+
+void NIFFile::unlock_cache ()
+{
+	if (--sCacheLockLevel)
+		sLockedFiles.clear ();
+}
+
+/// Open a NIF stream. The name is used for error messages.
+NIFFile::NIFFile(const std::string &name, psudo_private_modifier)
+    : filename(name)
+{
+	inp = Ogre::ResourceGroupManager::getSingleton().openResource(name);
+    parse();
+}
+
+NIFFile::~NIFFile()
+{
+	{
+		//TODO: hold lock on sLoadedMap while manipulating it...
+
+		loaded_map::iterator i = sLoadedMap.find (filename);
+
+		// its got to be in here, it just might not be us...
+		assert (i != sLoadedMap.end ());
+
+		// if weak_ptr is still expired, this resource hasn't been recreated
+		// between the initiation of the final release due to destruction
+		// of the last shared pointer and this thread acquiring the lock on
+		// the loader map
+		if (i->second.expired ())
+			sLoadedMap.erase (i);
+	}
+
+	// go ahead and perform the rest of the destruct outside the lock
+	// on sLoaderMap
+
+    for(std::size_t i=0; i<records.size(); i++)
+        delete records[i];
+}
+
+//NOTE: this is not thread safe, and it would probably be tricky to
+//		make it so. If the weak_ptr is expired before the destructor
+//		is called, then it would be relatively easy, otherwise
+//		a shared pointer is not the right solution
+NIFFile::ptr NIFFile::create (const std::string &name)
+{
+	//TODO: hold lock on sLoadedMap for whole function...
+
+	ptr result;
+
+	// lookup the resource
+	loaded_map::iterator i = sLoadedMap.find (name);
+
+	if (i == sLoadedMap.end ()) // it doesn't existing currently,
+	{							// or hasn't in the very near past
+
+		// create it now, for smoother threading if needed, the
+		// loading should be performed outside of the sLoaderMap
+		// lock and an alternate mechanism should be used to
+		// synchronize threads competing to load the same resource
+		result = boost::make_shared <NIFFile> (name, psudo_private_modifier());
+
+		// if we are locking the cache add an extra reference
+		// to keep the file in memory
+		if (sCacheLockLevel > 0)
+			sLockedFiles.push_back (result);
+
+		// stash a reference to the resource so that future
+		// calls can benefit
+		sLoadedMap [name] = boost::weak_ptr <NIFFile> (result);
+	}
+	else // it may (probably) still exists
+	{
+		// attempt to get the reference
+		result = i->second.lock ();
+
+		if (!result) // resource is in the process of being destroyed
+		{
+			// create a new instance, to replace the one that has
+			// begun the irreversible process of being destroyed
+			result = boost::make_shared <NIFFile> (name, psudo_private_modifier());
+
+			// respect the cache lock...
+			if (sCacheLockLevel > 0)
+				sLockedFiles.push_back (result);
+
+			// we potentially overwrite an expired pointer here
+			// but the other thread performing the delete on
+			// the previous copy of this resource will detect it
+			// and make sure not to erase the new reference
+			sLoadedMap [name] = boost::weak_ptr <NIFFile> (result);
+		}
+	}
+
+	// we made it!
+	return result;
+}
+
 /* This file implements functions from the NIFFile class. It is also
    where we stash all the functions we couldn't add as inline
    definitions in the record types.

--- a/components/nif/node.hpp
+++ b/components/nif/node.hpp
@@ -111,8 +111,8 @@ public:
         boneIndex = ind;
     }
 
-    Ogre::Matrix4 getLocalTransform();
-    Ogre::Matrix4 getWorldTransform();
+    Ogre::Matrix4 getLocalTransform() const;
+    Ogre::Matrix4 getWorldTransform() const;
 };
 
 struct NiNode : Node

--- a/components/nifbullet/bullet_nif_loader.cpp
+++ b/components/nifbullet/bullet_nif_loader.cpp
@@ -51,7 +51,7 @@ ManualBulletShapeLoader::~ManualBulletShapeLoader()
 }
 
 
-btQuaternion ManualBulletShapeLoader::getbtQuat(Ogre::Matrix3 &m)
+btQuaternion ManualBulletShapeLoader::getbtQuat(Ogre::Matrix3 const &m)
 {
     Ogre::Quaternion oquat(m);
     btQuaternion quat;
@@ -62,7 +62,7 @@ btQuaternion ManualBulletShapeLoader::getbtQuat(Ogre::Matrix3 &m)
     return quat;
 }
 
-btVector3 ManualBulletShapeLoader::getbtVector(Ogre::Vector3 &v)
+btVector3 ManualBulletShapeLoader::getbtVector(Ogre::Vector3 const &v)
 {
     return btVector3(v[0], v[1], v[2]);
 }
@@ -138,7 +138,7 @@ void ManualBulletShapeLoader::loadResource(Ogre::Resource *resource)
     }
 }
 
-bool ManualBulletShapeLoader::hasRootCollisionNode(Nif::Node* node)
+bool ManualBulletShapeLoader::hasRootCollisionNode(Nif::Node const * node)
 {
     if (node->recType == Nif::RC_NiNode)
     {
@@ -164,7 +164,7 @@ bool ManualBulletShapeLoader::hasRootCollisionNode(Nif::Node* node)
     return false;
 }
 
-void ManualBulletShapeLoader::handleNode(Nif::Node *node, int flags,
+void ManualBulletShapeLoader::handleNode(Nif::Node const *node, int flags,
    const Nif::Transformation *parentTrafo,bool hasCollisionNode,bool isCollisionNode,bool raycastingOnly)
 {
 
@@ -181,7 +181,7 @@ void ManualBulletShapeLoader::handleNode(Nif::Node *node, int flags,
     }
 
     // Check for extra data
-    Nif::Extra *e = node;
+    Nif::Extra const *e = node;
     while (!e->extra.empty())
     {
         // Get the next extra data in the list
@@ -232,7 +232,7 @@ void ManualBulletShapeLoader::handleNode(Nif::Node *node, int flags,
     {
 
         
-        btVector3 boxsize = getbtVector((node->boundXYZ));
+        btVector3 boxsize = getbtVector(node->boundXYZ);
         cShape->boxTranslation = node->boundPos;
         cShape->boxRotation = node->boundRot;
 
@@ -243,7 +243,7 @@ void ManualBulletShapeLoader::handleNode(Nif::Node *node, int flags,
     // For NiNodes, loop through children
     if (node->recType == Nif::RC_NiNode)
     {
-        Nif::NodeList &list = ((Nif::NiNode*)node)->children;
+        Nif::NodeList const &list = ((Nif::NiNode const *)node)->children;
         int n = list.length();
         for (int i=0; i<n; i++)
         {
@@ -256,7 +256,7 @@ void ManualBulletShapeLoader::handleNode(Nif::Node *node, int flags,
     else if (node->recType == Nif::RC_NiTriShape && (isCollisionNode || !hasCollisionNode))
     {
         cShape->mCollide = !(flags&0x800);
-        handleNiTriShape(dynamic_cast<Nif::NiTriShape *>(node), flags,childTrafo.rotation,childTrafo.pos,childTrafo.scale,raycastingOnly);
+        handleNiTriShape(dynamic_cast<Nif::NiTriShape const *>(node), flags,childTrafo.rotation,childTrafo.pos,childTrafo.scale,raycastingOnly);
     }
     else if(node->recType == Nif::RC_RootCollisionNode)
     {
@@ -270,7 +270,7 @@ void ManualBulletShapeLoader::handleNode(Nif::Node *node, int flags,
     }
 }
 
-void ManualBulletShapeLoader::handleNiTriShape(Nif::NiTriShape *shape, int flags,Ogre::Matrix3 parentRot,Ogre::Vector3 parentPos,float parentScale,
+void ManualBulletShapeLoader::handleNiTriShape(Nif::NiTriShape const *shape, int flags,Ogre::Matrix3 parentRot,Ogre::Vector3 parentPos,float parentScale,
     bool raycastingOnly)
 {
     assert(shape != NULL);

--- a/components/nifbullet/bullet_nif_loader.cpp
+++ b/components/nifbullet/bullet_nif_loader.cpp
@@ -82,7 +82,8 @@ void ManualBulletShapeLoader::loadResource(Ogre::Resource *resource)
     // of the early stages of development. Right now we WANT to catch
     // every error as early and intrusively as possible, as it's most
     // likely a sign of incomplete code rather than faulty input.
-    Nif::NIFFile nif(resourceName.substr(0, resourceName.length()-7));
+    Nif::NIFFile::ptr pnif (Nif::NIFFile::create (resourceName.substr(0, resourceName.length()-7)));
+    Nif::NIFFile & nif = *pnif.get ();
     if (nif.numRecords() < 1)
     {
         warn("Found no records in NIF.");

--- a/components/nifbullet/bullet_nif_loader.hpp
+++ b/components/nifbullet/bullet_nif_loader.hpp
@@ -79,25 +79,25 @@ public:
     void load(const std::string &name,const std::string &group);
 
 private:
-    btQuaternion getbtQuat(Ogre::Matrix3 &m);
+    btQuaternion getbtQuat(Ogre::Matrix3 const &m);
 
-    btVector3 getbtVector(Ogre::Vector3 &v);
+    btVector3 getbtVector(Ogre::Vector3 const &v);
 
     /**
     *Parse a node.
     */
-    void handleNode(Nif::Node *node, int flags,
+    void handleNode(Nif::Node const *node, int flags,
         const Nif::Transformation *trafo, bool hasCollisionNode,bool isCollisionNode,bool raycastingOnly);
 
     /**
     *Helper function
     */
-    bool hasRootCollisionNode(Nif::Node* node);
+    bool hasRootCollisionNode(Nif::Node const * node);
 
     /**
     *convert a NiTriShape to a bullet trishape.
     */
-    void handleNiTriShape(Nif::NiTriShape *shape, int flags,Ogre::Matrix3 parentRot,Ogre::Vector3 parentPos,float parentScales,bool raycastingOnly);
+    void handleNiTriShape(Nif::NiTriShape const *shape, int flags,Ogre::Matrix3 parentRot,Ogre::Vector3 parentPos,float parentScales,bool raycastingOnly);
 
     std::string resourceName;
     std::string resourceGroup;

--- a/components/nifogre/ogre_nif_loader.cpp
+++ b/components/nifogre/ogre_nif_loader.cpp
@@ -228,7 +228,8 @@ void loadResource(Ogre::Resource *resource)
     Ogre::Skeleton *skel = dynamic_cast<Ogre::Skeleton*>(resource);
     OgreAssert(skel, "Attempting to load a skeleton into a non-skeleton resource!");
 
-    Nif::NIFFile nif(skel->getName());
+    Nif::NIFFile::ptr pnif(Nif::NIFFile::create (skel->getName()));
+    Nif::NIFFile & nif = *pnif.get ();
     const Nif::Node *node = dynamic_cast<const Nif::Node*>(nif.getRecord(0));
 
     std::vector<Nif::NiKeyframeController const*> ctrls;
@@ -952,8 +953,8 @@ public:
             return;
         }
 
-        Nif::NIFFile nif(mName);
-        Nif::Node const *node = dynamic_cast<Nif::Node const *>(nif.getRecord(0));
+        Nif::NIFFile::ptr nif = Nif::NIFFile::create (mName);
+        Nif::Node const *node = dynamic_cast<Nif::Node const *>(nif->getRecord(0));
         findTriShape(mesh, node);
     }
 
@@ -1044,7 +1045,8 @@ MeshPairList NIFLoader::load(std::string name, std::string skelName, TextKeyMap 
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
     std::transform(skelName.begin(), skelName.end(), skelName.begin(), ::tolower);
 
-    Nif::NIFFile nif(name);
+    Nif::NIFFile::ptr pnif = Nif::NIFFile::create (name);
+    Nif::NIFFile & nif = *pnif.get ();
     if (nif.numRecords() < 1)
     {
         nif.warn("Found no records in NIF.");

--- a/components/nifogre/ogre_nif_loader.cpp
+++ b/components/nifogre/ogre_nif_loader.cpp
@@ -174,7 +174,7 @@ static void insertTextKeys(const Nif::NiTextKeyExtraData *tk, TextKeyMap *textke
 }
 
 
-void buildBones(Ogre::Skeleton *skel, const Nif::Node *node, std::vector<Nif::NiKeyframeController*> &ctrls, Ogre::Bone *parent=NULL)
+void buildBones(Ogre::Skeleton *skel, const Nif::Node *node, std::vector<Nif::NiKeyframeController const*> &ctrls, Ogre::Bone *parent=NULL)
 {
     Ogre::Bone *bone;
     if(!skel->hasBone(node->name))
@@ -231,7 +231,7 @@ void loadResource(Ogre::Resource *resource)
     Nif::NIFFile nif(skel->getName());
     const Nif::Node *node = dynamic_cast<const Nif::Node*>(nif.getRecord(0));
 
-    std::vector<Nif::NiKeyframeController*> ctrls;
+    std::vector<Nif::NiKeyframeController const*> ctrls;
     buildBones(skel, node, ctrls);
 
     std::vector<std::string> targets;
@@ -242,7 +242,7 @@ void loadResource(Ogre::Resource *resource)
     float maxtime = 0.0f;
     for(size_t i = 0;i < ctrls.size();i++)
     {
-        Nif::NiKeyframeController *ctrl = ctrls[i];
+        Nif::NiKeyframeController const *ctrl = ctrls[i];
         maxtime = std::max(maxtime, ctrl->timeStop);
         Nif::Named *target = dynamic_cast<Nif::Named*>(ctrl->target.getPtr());
         if(target != NULL)
@@ -265,8 +265,8 @@ void loadResource(Ogre::Resource *resource)
 
     for(size_t i = 0;i < ctrls.size();i++)
     {
-        Nif::NiKeyframeController *kfc = ctrls[i];
-        Nif::NiKeyframeData *kf = kfc->data.getPtr();
+        Nif::NiKeyframeController const *kfc = ctrls[i];
+        Nif::NiKeyframeData const *kf = kfc->data.getPtr();
 
         /* Get the keyframes and make sure they're sorted first to last */
         QuaternionKeyList quatkeys = kf->mRotations;
@@ -707,7 +707,7 @@ class NIFMeshLoader : Ogre::ManualResourceLoader
 
 
     // Convert NiTriShape to Ogre::SubMesh
-    void handleNiTriShape(Ogre::Mesh *mesh, Nif::NiTriShape *shape)
+    void handleNiTriShape(Ogre::Mesh *mesh, Nif::NiTriShape const *shape)
     {
         Ogre::SkeletonPtr skel;
         const Nif::NiTriShapeData *data = shape->data.getPtr();
@@ -905,18 +905,18 @@ class NIFMeshLoader : Ogre::ManualResourceLoader
             sub->setMaterialName(mMaterialName);
     }
 
-    bool findTriShape(Ogre::Mesh *mesh, Nif::Node *node)
+    bool findTriShape(Ogre::Mesh *mesh, Nif::Node const *node)
     {
         if(node->recType == Nif::RC_NiTriShape && mShapeName == node->name)
         {
-            handleNiTriShape(mesh, dynamic_cast<Nif::NiTriShape*>(node));
+            handleNiTriShape(mesh, dynamic_cast<Nif::NiTriShape const *>(node));
             return true;
         }
 
-        Nif::NiNode *ninode = dynamic_cast<Nif::NiNode*>(node);
+        Nif::NiNode const *ninode = dynamic_cast<Nif::NiNode const *>(node);
         if(ninode)
         {
-            Nif::NodeList &children = ninode->children;
+            Nif::NodeList const &children = ninode->children;
             for(size_t i = 0;i < children.length();i++)
             {
                 if(!children[i].empty())
@@ -953,7 +953,7 @@ public:
         }
 
         Nif::NIFFile nif(mName);
-        Nif::Node *node = dynamic_cast<Nif::Node*>(nif.getRecord(0));
+        Nif::Node const *node = dynamic_cast<Nif::Node const *>(nif.getRecord(0));
         findTriShape(mesh, node);
     }
 
@@ -1052,10 +1052,10 @@ MeshPairList NIFLoader::load(std::string name, std::string skelName, TextKeyMap 
     }
 
     // The first record is assumed to be the root node
-    Nif::Record *r = nif.getRecord(0);
+    Nif::Record const *r = nif.getRecord(0);
     assert(r != NULL);
 
-    Nif::Node *node = dynamic_cast<Nif::Node*>(r);
+    Nif::Node const *node = dynamic_cast<Nif::Node const *>(r);
     if(node == NULL)
     {
         nif.warn("First record in file was not a node, but a "+


### PR DESCRIPTION
This patch adds a cache for loaded and parsed NIF files so that repeated requests for the same NIF file during loading sequences (currently engine startup, and cellChange) don't perform excessive work.
