### PR TITLE
Bug #495: Activation Range

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -427,12 +427,7 @@ void OMW::Engine::activate()
     if (MWBase::Environment::get().getWindowManager()->isGuiMode())
         return;
 
-    std::string handle = MWBase::Environment::get().getWorld()->getFacedHandle();
-
-    if (handle.empty())
-        return;
-
-    MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->searchPtrViaHandle (handle);
+    MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getFacedHandle();
 
     if (ptr.isEmpty())
         return;

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -199,8 +199,8 @@ namespace MWBase
 
             virtual void markCellAsUnchanged() = 0;
 
-            virtual std::string getFacedHandle() = 0;
-            ///< Return handle of the object the player is looking at
+            virtual MWWorld::Ptr  getFacedHandle() = 0;
+            ///< Return pointer to the object the player is looking at, if it is within activation range
 
             virtual void deleteObject (const MWWorld::Ptr& ptr) = 0;
 

--- a/apps/openmw/mwgui/hud.cpp
+++ b/apps/openmw/mwgui/hud.cpp
@@ -244,8 +244,7 @@ void HUD::onWorldClicked(MyGUI::Widget* _sender)
         if ( (mode != GM_Console) && (mode != GM_Container) && (mode != GM_Inventory) )
             return;
 
-        std::string handle = MWBase::Environment::get().getWorld()->getFacedHandle();
-        MWWorld::Ptr object = MWBase::Environment::get().getWorld()->searchPtrViaHandle(handle);
+        MWWorld::Ptr object = MWBase::Environment::get().getWorld()->getFacedHandle();
 
         if (mode == GM_Console)
             MWBase::Environment::get().getWindowManager()->getConsole()->setSelectedObject(object);

--- a/apps/openmw/mwgui/tooltips.cpp
+++ b/apps/openmw/mwgui/tooltips.cpp
@@ -80,11 +80,7 @@ void ToolTips::onFrame(float frameDuration)
             || (mWindowManager->getMode() == GM_Container)
             || (mWindowManager->getMode() == GM_Inventory)))
         {
-            std::string handle = MWBase::Environment::get().getWorld()->getFacedHandle();
-
-            mFocusObject = MWBase::Environment::get().getWorld()->searchPtrViaHandle(handle);
-            if (mFocusObject.isEmpty ())
-                return;
+            mFocusObject = MWBase::Environment::get().getWorld()->getFacedHandle();
 
             MyGUI::IntSize tooltipSize = getToolTipViaPtr(true);
 

--- a/apps/openmw/mwworld/physicssystem.cpp
+++ b/apps/openmw/mwworld/physicssystem.cpp
@@ -20,6 +20,7 @@
 using namespace Ogre;
 namespace MWWorld
 {
+    static float query_distance = 500;
 
     PhysicsSystem::PhysicsSystem(OEngine::Render::OgreRenderer &_rend) :
         mRender(_rend), mEngine(0), mFreeFly (true)
@@ -56,8 +57,11 @@ namespace MWWorld
             mPlayerData.eyepos.z);
         origin += dir * 5;
 
-        btVector3 dest = origin + dir * 500;
-        return mEngine->rayTest(origin, dest);
+        btVector3 dest = origin + dir * query_distance; /// \todo make this distance a parameter
+        std::pair <std::string, float> result;
+        /*auto*/ result = mEngine->rayTest(origin, dest);
+        result.second *= query_distance;
+        return result;
     }
 
     std::vector < std::pair <float, std::string> > PhysicsSystem::getFacedObjects ()
@@ -73,22 +77,32 @@ namespace MWWorld
             mPlayerData.eyepos.z);
         origin += dir * 5;
 
-        btVector3 dest = origin + dir * 500;
-        return mEngine->rayTest2(origin, dest);
+        btVector3 dest = origin + dir * query_distance; /// \todo make this distance a parameter
+        std::vector < std::pair <float, std::string> > results;
+        /* auto */ results = mEngine->rayTest2(origin, dest);
+        std::vector < std::pair <float, std::string> >::iterator i;
+        for (/* auto */ i = results.begin (); i != results.end (); ++i)
+            i->first *= query_distance;
+        return results;
     }
 
     std::vector < std::pair <float, std::string> > PhysicsSystem::getFacedObjects (float mouseX, float mouseY)
     {
         Ray ray = mRender.getCamera()->getCameraToViewportRay(mouseX, mouseY);
         Ogre::Vector3 from = ray.getOrigin();
-        Ogre::Vector3 to = ray.getPoint(500); /// \todo make this distance (ray length) configurable
+        Ogre::Vector3 to = ray.getPoint(query_distance); /// \todo make this distance a parameter
 
         btVector3 _from, _to;
         // OGRE to MW coordinates
         _from = btVector3(from.x, -from.z, from.y);
         _to = btVector3(to.x, -to.z, to.y);
 
-        return mEngine->rayTest2(_from,_to);
+        std::vector < std::pair <float, std::string> > results;
+        /* auto */ results = mEngine->rayTest2(_from,_to);
+        std::vector < std::pair <float, std::string> >::iterator i;
+        for (/* auto */ i = results.begin (); i != results.end (); ++i)
+            i->first *= query_distance;
+        return results;
     }
 
     void PhysicsSystem::setCurrentWater(bool hasWater, int waterHeight)
@@ -110,7 +124,7 @@ namespace MWWorld
         Ray centerRay = mRender.getCamera()->getCameraToViewportRay(
         mRender.getViewport()->getWidth()/2,
         mRender.getViewport()->getHeight()/2);
-        btVector3 result(centerRay.getPoint(500*extent).x,-centerRay.getPoint(500*extent).z,centerRay.getPoint(500*extent).y); /// \todo make this distance (ray length) configurable
+        btVector3 result(centerRay.getPoint(extent).x,-centerRay.getPoint(extent).z,centerRay.getPoint(extent).y);
         return result;
     }
 
@@ -118,7 +132,7 @@ namespace MWWorld
     {
         //get a ray pointing to the center of the viewport
         Ray centerRay = mRender.getCamera()->getCameraToViewportRay(mouseX, mouseY);
-        btVector3 result(centerRay.getPoint(500*extent).x,-centerRay.getPoint(500*extent).z,centerRay.getPoint(500*extent).y); /// \todo make this distance (ray length) configurable
+        btVector3 result(centerRay.getPoint(extent).x,-centerRay.getPoint(extent).z,centerRay.getPoint(extent).y);
         return result;
     }
 
@@ -192,7 +206,7 @@ namespace MWWorld
         pm_ref.upmove = 0;
        
 
-		//playerphysics->ps.move_type = PM_NOCLIP;
+        //playerphysics->ps.move_type = PM_NOCLIP;
         for (std::vector<std::pair<std::string, Ogre::Vector3> >::const_iterator iter (actors.begin());
             iter!=actors.end(); ++iter)
         {

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -72,10 +72,13 @@ namespace MWWorld
             Ptr getPtrViaHandle (const std::string& handle, Ptr::CellStore& cellStore);
 
             std::string mFacedHandle;
+            float mFacedDistance;
             Ptr mFaced1;
             Ptr mFaced2;
             std::string mFaced1Name;
             std::string mFaced2Name;
+            float mFaced1Distance;
+            float mFaced2Distance;
             int mNumFacing;
             std::map<std::string,std::string> mFallback;
 
@@ -89,6 +92,13 @@ namespace MWWorld
 
             virtual void
             copyObjectToCell(const Ptr &ptr, CellStore &cell, const ESM::Position &pos);
+
+            void updateWindowManager ();
+            void performUpdateSceneQueries ();
+            void processFacedQueryResults (MWRender::OcclusionQuery* query);
+            void beginFacedQueryProcess (MWRender::OcclusionQuery* query);
+            void beginSingleFacedQueryProcess (MWRender::OcclusionQuery* query, std::vector < std::pair < float, std::string > > & results);
+            void beginDoubleFacedQueryProcess (MWRender::OcclusionQuery* query, std::vector < std::pair < float, std::string > > & results);
 
         public:
 
@@ -217,8 +227,8 @@ namespace MWWorld
 
             virtual void markCellAsUnchanged();
 
-            virtual std::string getFacedHandle();
-            ///< Return handle of the object the player is looking at
+            virtual MWWorld::Ptr getFacedHandle();
+            ///< Return pointer to the object the player is looking at, if it is within activation range
 
             virtual void deleteObject (const Ptr& ptr);
 


### PR DESCRIPTION
This is superseded by pull request #507
- Changed MWWorld::PhysicsSystem to report the correct distance for
  hits.
- Changed MWWorld::World to remember the distances when using occlusion
  queries.
- Changed MWWorld::World::getFacedHandle to return a pointer to last hit
  object only if it is within activation range.
- Changed users of getFacedHandle to deal with the change in signature.
- Broke MWWorld::World::update into several functions.
