### PR TITLE
fixed linear light model (gamma-correct rendering) and light positions

### DIFF
--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -35,15 +35,16 @@ namespace MWClass
         MWRender::Objects& objects = renderingInterface.getObjects();
         objects.insertBegin(ptr, ptr.getRefData().isEnabled(), false);
 
+        Ogre::Vector3 lightPos(0,0,0); //light should be placed at (0,0,0) if there is no mesh
         if (!model.empty())
-            objects.insertMesh(ptr, "meshes\\" + model);
+            objects.insertMesh(ptr, "meshes\\" + model, &lightPos);
 
         const int color = ref->mBase->mData.mColor;
         const float r = ((color >> 0) & 0xFF) / 255.0f;
         const float g = ((color >> 8) & 0xFF) / 255.0f;
         const float b = ((color >> 16) & 0xFF) / 255.0f;
         const float radius = float (ref->mBase->mData.mRadius);
-        objects.insertLight (ptr, r, g, b, radius);
+        objects.insertLight (ptr, r, g, b, radius, lightPos);
     }
 
     void Light::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const

--- a/apps/openmw/mwclass/light.hpp
+++ b/apps/openmw/mwclass/light.hpp
@@ -12,7 +12,7 @@ namespace MWClass
 
         public:
 
-             virtual void insertObjectRendering (const MWWorld::Ptr& ptr, MWRender::RenderingInterface& renderingInterface) const;
+            virtual void insertObjectRendering (const MWWorld::Ptr& ptr, MWRender::RenderingInterface& renderingInterface) const;
             ///< Add reference into a cell for rendering
 
             virtual void insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const;

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -21,7 +21,7 @@ using namespace MWRender;
 float Objects::lightLinearValue = 3;
 float Objects::lightLinearRadiusMult = 1;
 
-float Objects::lightQuadraticValue = 16;
+float Objects::lightQuadraticValue = 4;
 float Objects::lightQuadraticRadiusMult = 1;
 
 bool Objects::lightOutQuadInLin = true;
@@ -209,6 +209,9 @@ void Objects::insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, f
     Ogre::SceneNode* insert = mRenderer.getScene()->getSceneNode(ptr.getRefData().getHandle());
     assert(insert);
     Ogre::Light *light = mRenderer.getScene()->createLight();
+    // Convert values into a linear color space for gamma-correct rendering.
+    // Conversion is done here as opposed to the shader to save shader runtime.
+    sRGB2linear(&r,&g,&b);
     light->setDiffuseColour (r, g, b);
 
     MWWorld::LiveCellRef<ESM::Light> *ref = ptr.get<ESM::Light>();
@@ -238,30 +241,9 @@ void Objects::insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, f
     info.time = Ogre::Math::RangeRandom(-500, +500);
     info.phase = Ogre::Math::RangeRandom(-500, +500);
 
-    // adjust the lights depending if we're in an interior or exterior cell
-    // quadratic means the light intensity falls off quite fast, resulting in a
-    // dark, atmospheric environment (perfect for exteriors)
-    // for interiors, we want more "warm" lights, so use linear attenuation.
-    bool quadratic = false;
-    if (!lightOutQuadInLin)
-        quadratic = lightQuadratic;
-    else
-    {
-        quadratic = !info.interior;
-    }
-
-    if (!quadratic)
-    {
-        float r = radius * lightLinearRadiusMult;
-        float attenuation = lightLinearValue / r;
-        light->setAttenuation(r*10, 0, attenuation, 0);
-    }
-    else
-    {
-        float r = radius * lightQuadraticRadiusMult;
-        float attenuation = lightQuadraticValue / pow(r, 2);
-        light->setAttenuation(r*10, 0, 0, attenuation);
-    }
+    float quadRadius = radius * lightQuadraticRadiusMult;
+    float attenuation = lightQuadraticValue / pow(quadRadius, 2);
+    light->setAttenuation(quadRadius*10, 0, 0, attenuation);
 
     insert->attachObject(light);
     mLights.push_back(info);
@@ -518,5 +500,17 @@ void Objects::updateObjectCell(const MWWorld::Ptr &ptr)
     /// \note Still unaware how to move aabb and static w/o full rebuild,
     /// moving static objects may cause problems
     insertMesh(ptr, MWWorld::Class::get(ptr).getModel(ptr));
+}
+
+void Objects::sRGB2linear (float *r, float *g, float *b)
+{
+	*r=pow(*r,2.2);
+	*g=pow(*g,2.2);
+	*b=pow(*b,2.2);
+}
+
+void Objects::sRGB2linear (Ogre::ColourValue *color)
+{
+	Objects::sRGB2linear(&color->r,&color->g,&color->b);
 }
 

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -87,13 +87,12 @@ void Objects::insertBegin (const MWWorld::Ptr& ptr, bool enabled, bool static_)
     mIsStatic = static_;
 }
 
-void Objects::insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh)
+void Objects::insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh, Ogre::Vector3 *lightPos)
 {
     Ogre::SceneNode* insert = ptr.getRefData().getBaseNode();
     assert(insert);
-
     Ogre::AxisAlignedBox bounds = Ogre::AxisAlignedBox::BOX_NULL;
-    NifOgre::EntityList entities = NifOgre::NIFLoader::createEntities(insert, NULL, mesh);
+    NifOgre::EntityList entities = NifOgre::NIFLoader::createEntities(insert, NULL, mesh, lightPos);
     for(size_t i = 0;i < entities.mEntities.size();i++)
     {
         const Ogre::AxisAlignedBox &tmp = entities.mEntities[i]->getBoundingBox();
@@ -204,17 +203,18 @@ void Objects::insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh)
     }
 }
 
-void Objects::insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius)
+void Objects::insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius, const Ogre::Vector3& pos)
 {
     Ogre::SceneNode* insert = mRenderer.getScene()->getSceneNode(ptr.getRefData().getHandle());
     assert(insert);
     Ogre::Light *light = mRenderer.getScene()->createLight();
+    MWWorld::LiveCellRef<ESM::Light> *ref = ptr.get<ESM::Light>();
+
     // Convert values into a linear color space for gamma-correct rendering.
     // Conversion is done here as opposed to the shader to save shader runtime.
     sRGB2linear(&r,&g,&b);
     light->setDiffuseColour (r, g, b);
 
-    MWWorld::LiveCellRef<ESM::Light> *ref = ptr.get<ESM::Light>();
 
     LightInfo info;
     info.name = light->getName();
@@ -244,7 +244,7 @@ void Objects::insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, f
     float quadRadius = radius * lightQuadraticRadiusMult;
     float attenuation = lightQuadraticValue / pow(quadRadius, 2);
     light->setAttenuation(quadRadius*10, 0, 0, attenuation);
-
+    light->setPosition(pos);
     insert->attachObject(light);
     mLights.push_back(info);
 }

--- a/apps/openmw/mwrender/objects.hpp
+++ b/apps/openmw/mwrender/objects.hpp
@@ -68,12 +68,14 @@ class Objects{
     void clearSceneNode (Ogre::SceneNode *node);
     ///< Remove all movable objects from \a node.
 
+
 public:
     Objects(OEngine::Render::OgreRenderer& renderer): mRenderer (renderer), mIsStatic(false) {}
     ~Objects(){}
     void insertBegin (const MWWorld::Ptr& ptr, bool enabled, bool static_);
     void insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh);
     void insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius);
+    ///< color is assumed to be in sRGB space
 
     void enableLights();
     void disableLights();
@@ -95,6 +97,11 @@ public:
 
     /// Updates containing cell for object rendering data
     void updateObjectCell(const MWWorld::Ptr &ptr);
+
+    static void sRGB2linear (float *r, float *g, float *b);
+    ///< transform r,g,b into a linear color space. uses the same approximation as the object shader.
+    static void sRGB2linear (Ogre::ColourValue *color);
+    ///< transform color into a linear color space. uses the same approximation as the object shader.
 };
 }
 #endif

--- a/apps/openmw/mwrender/objects.hpp
+++ b/apps/openmw/mwrender/objects.hpp
@@ -66,15 +66,15 @@ class Objects{
     static bool lightOutQuadInLin;
 
     void clearSceneNode (Ogre::SceneNode *node);
-    ///< Remove all movable objects from \a node.
+	///< Remove all movable objects from \a node.
 
 
 public:
     Objects(OEngine::Render::OgreRenderer& renderer): mRenderer (renderer), mIsStatic(false) {}
     ~Objects(){}
     void insertBegin (const MWWorld::Ptr& ptr, bool enabled, bool static_);
-    void insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh);
-    void insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius);
+    void insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh, Ogre::Vector3 *lightPos=NULL);
+    void insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius, const Ogre::Vector3& pos);
     ///< color is assumed to be in sRGB space
 
     void enableLights();

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -266,10 +266,10 @@ bool RenderingManager::rotateObject( const MWWorld::Ptr &ptr, Ogre::Vector3 &rot
     bool isActive = ptr.getRefData().getBaseNode() != 0;
     bool isPlayer = isActive && ptr.getRefData().getHandle() == "player";
     bool force = true;
-    
+
     if (isPlayer)
         force = mPlayer->rotate(rot, adjust);
-    
+
     MWWorld::Class::get(ptr).adjustRotation(ptr, rot.x, rot.y, rot.z);
 
     if (!isPlayer && isActive)
@@ -358,7 +358,7 @@ void RenderingManager::update (float duration, bool paused)
 
     mSkyManager->setGlare(mOcclusionQuery->getSunVisibility());
 
-    MWWorld::RefData &data = 
+    MWWorld::RefData &data =
         MWBase::Environment::get()
             .getWorld()
             ->getPlayer()
@@ -557,6 +557,7 @@ void RenderingManager::configureAmbient(MWWorld::Ptr::CellStore &mCell)
     }
     Ogre::ColourValue colour;
     colour.setAsABGR (mCell.mCell->mAmbi.mSunlight);
+    Objects::sRGB2linear(&colour);
     mSun->setDiffuseColour (colour);
     mSun->setType(Ogre::Light::LT_DIRECTIONAL);
     mSun->setDirection(0,-1,0);
@@ -594,15 +595,19 @@ void RenderingManager::skipAnimation (const MWWorld::Ptr& ptr)
 void RenderingManager::setSunColour(const Ogre::ColourValue& colour)
 {
     if (!mSunEnabled) return;
-    mSun->setDiffuseColour(colour);
-    mSun->setSpecularColour(colour);
-    mTerrainManager->setDiffuse(colour);
+    Ogre::ColourValue newColour(colour);
+    Objects::sRGB2linear(&newColour);
+    mSun->setDiffuseColour(newColour);
+    mSun->setSpecularColour(newColour);
+    mTerrainManager->setDiffuse(newColour);
 }
 
 void RenderingManager::setAmbientColour(const Ogre::ColourValue& colour)
 {
-    mRendering.getScene()->setAmbientLight(colour);
-    mTerrainManager->setAmbient(colour);
+    Ogre::ColourValue newColour(colour);
+    Objects::sRGB2linear(&newColour);
+    mRendering.getScene()->setAmbientLight(newColour);
+    mTerrainManager->setAmbient(newColour);
 }
 
 void RenderingManager::sunEnable()

--- a/components/nifogre/ogre_nif_loader.hpp
+++ b/components/nifogre/ogre_nif_loader.hpp
@@ -69,7 +69,7 @@ typedef std::vector< std::pair<std::string,std::string> > MeshPairList;
  */
 class NIFLoader
 {
-    static MeshPairList load(std::string name, std::string skelName, const std::string &group);
+    static MeshPairList load(std::string name, std::string skelName, const std::string &group, Ogre::Vector3 *lightPos=NULL);
 
 public:
     static EntityList createEntities(Ogre::Entity *parent, const std::string &bonename,
@@ -80,6 +80,7 @@ public:
     static EntityList createEntities(Ogre::SceneNode *parent,
                                      TextKeyMap *textkeys,
                                      const std::string &name,
+                                     Ogre::Vector3 *lightPos=NULL,
                                      const std::string &group="General");
 };
 

--- a/files/materials/core.h
+++ b/files/materials/core.h
@@ -1,5 +1,5 @@
-#define gammaCorrectRead(v) pow(max(v, 0.00001f), float3(gammaCorrection,gammaCorrection,gammaCorrection))
-#define gammaCorrectOutput(v) pow(max(v, 0.00001f), float3(1.f/gammaCorrection,1.f/gammaCorrection,1.f/gammaCorrection))
+#define gammaCorrectRead(v) pow(v, float3(2.2f,2.2f,2.2f))
+#define gammaCorrectOutput(v) pow(v, float3(1.f/2.2f,1.f/2.2f,1.f/2.2f))
 
 
 
@@ -12,7 +12,7 @@
     #define shSaturate(a) saturate(a)
 
     #define shSampler2D(name) , uniform sampler2D name : register(s@shCounter(0)) @shUseSampler(name)
-    
+
     #define shSamplerCube(name) , uniform samplerCUBE name : register(s@shCounter(0)) @shUseSampler(name)
 
     #define shMatrixMult(m, v) mul(m, v)
@@ -25,7 +25,7 @@
     #define shOutput(type, name) , out type name : TEXCOORD@shCounter(2)
 
     #define shNormalInput(type) , in type normal : NORMAL
-    
+
     #define shColourInput(type) , in type colour : COLOR
 
     #ifdef SH_VERTEX_SHADER
@@ -89,10 +89,10 @@
 
     #define float4x4 mat4
     #define float3x3 mat3
-    
+
     // GLSL 1.3
     #if 0
-    
+
     // automatically recognized by ogre when the input name equals this
     #define shInputPosition vertex
 
@@ -127,13 +127,13 @@
 
 
     #endif
-    
+
     #endif
-    
+
     // GLSL 1.2
-    
+
     #if 1
-    
+
     // automatically recognized by ogre when the input name equals this
     #define shInputPosition vertex
 
@@ -151,7 +151,7 @@
     #ifdef SH_VERTEX_SHADER
 
         #define SH_BEGIN_PROGRAM \
-            attribute vec4 vertex; 
+            attribute vec4 vertex;
         #define SH_START_PROGRAM \
             void main(void)
 
@@ -159,15 +159,15 @@
 
     #ifdef SH_FRAGMENT_SHADER
 
-        #define shDeclareMrtOutput(num) 
+        #define shDeclareMrtOutput(num)
 
         #define SH_BEGIN_PROGRAM
-        
+
         #define SH_START_PROGRAM \
             void main(void)
 
 
     #endif
-    
+
     #endif
 #endif


### PR DESCRIPTION
First commit: Bug #520, Gamma Correction wrong with default settings
The linearization was missing a few things, especially linearization of lights. This is now added.
Because of that, the gamma-slider doesn't have any effect anymore. It never should have had one, the gamma for shading and light calculation shouldn't be influenced by the user.
Just as a small clarification: The implementation from scrawl was meant to introduce "gamma-correct rendering" but was a bit of a mix between "gamma-correct rendering" and "gamma correction of the output image". This change should now introduce pure "gamma-correct rendering".

Second commit: Feature #367, Lights that behave more like original morrowind implementation
Calculates the offsets inside the mesh needed for correct placement of the lights from the nif files (if available) and uses them.
I'm just pushing them through the whole chain from reading the nif file to adding the light. For the future, we'll need some more unified structure that also keeps track of things like smoke, flames, etc.
