### PR TITLE
fixed light positioning

### DIFF
--- a/apps/openmw/mwclass/light.cpp
+++ b/apps/openmw/mwclass/light.cpp
@@ -35,15 +35,16 @@ namespace MWClass
         MWRender::Objects& objects = renderingInterface.getObjects();
         objects.insertBegin(ptr, ptr.getRefData().isEnabled(), false);
 
+        Ogre::Vector3 lightPos(0,0,0); //light should be placed at (0,0,0) if there is no mesh
         if (!model.empty())
-            objects.insertMesh(ptr, "meshes\\" + model);
+            objects.insertMesh(ptr, "meshes\\" + model, &lightPos);
 
         const int color = ref->mBase->mData.mColor;
         const float r = ((color >> 0) & 0xFF) / 255.0f;
         const float g = ((color >> 8) & 0xFF) / 255.0f;
         const float b = ((color >> 16) & 0xFF) / 255.0f;
         const float radius = float (ref->mBase->mData.mRadius);
-        objects.insertLight (ptr, r, g, b, radius);
+        objects.insertLight (ptr, r, g, b, radius, lightPos);
     }
 
     void Light::insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const

--- a/apps/openmw/mwclass/light.hpp
+++ b/apps/openmw/mwclass/light.hpp
@@ -12,7 +12,7 @@ namespace MWClass
 
         public:
 
-             virtual void insertObjectRendering (const MWWorld::Ptr& ptr, MWRender::RenderingInterface& renderingInterface) const;
+            virtual void insertObjectRendering (const MWWorld::Ptr& ptr, MWRender::RenderingInterface& renderingInterface) const;
             ///< Add reference into a cell for rendering
 
             virtual void insertObject(const MWWorld::Ptr& ptr, MWWorld::PhysicsSystem& physics) const;

--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -87,13 +87,12 @@ void Objects::insertBegin (const MWWorld::Ptr& ptr, bool enabled, bool static_)
     mIsStatic = static_;
 }
 
-void Objects::insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh)
+void Objects::insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh, Ogre::Vector3 *lightPos)
 {
     Ogre::SceneNode* insert = ptr.getRefData().getBaseNode();
     assert(insert);
-
     Ogre::AxisAlignedBox bounds = Ogre::AxisAlignedBox::BOX_NULL;
-    NifOgre::EntityList entities = NifOgre::NIFLoader::createEntities(insert, NULL, mesh);
+    NifOgre::EntityList entities = NifOgre::NIFLoader::createEntities(insert, NULL, mesh, lightPos);
     for(size_t i = 0;i < entities.mEntities.size();i++)
     {
         const Ogre::AxisAlignedBox &tmp = entities.mEntities[i]->getBoundingBox();
@@ -204,7 +203,7 @@ void Objects::insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh)
     }
 }
 
-void Objects::insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius)
+void Objects::insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius, const Ogre::Vector3& pos)
 {
     Ogre::SceneNode* insert = mRenderer.getScene()->getSceneNode(ptr.getRefData().getHandle());
     assert(insert);
@@ -263,6 +262,7 @@ void Objects::insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, f
         light->setAttenuation(r*10, 0, 0, attenuation);
     }
 
+    light->setPosition(pos);
     insert->attachObject(light);
     mLights.push_back(info);
 }

--- a/apps/openmw/mwrender/objects.hpp
+++ b/apps/openmw/mwrender/objects.hpp
@@ -72,8 +72,8 @@ public:
     Objects(OEngine::Render::OgreRenderer& renderer): mRenderer (renderer), mIsStatic(false) {}
     ~Objects(){}
     void insertBegin (const MWWorld::Ptr& ptr, bool enabled, bool static_);
-    void insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh);
-    void insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius);
+    void insertMesh (const MWWorld::Ptr& ptr, const std::string& mesh, Ogre::Vector3 *lightPos=NULL);
+    void insertLight (const MWWorld::Ptr& ptr, float r, float g, float b, float radius, const Ogre::Vector3& pos);
 
     void enableLights();
     void disableLights();

--- a/components/nifogre/ogre_nif_loader.hpp
+++ b/components/nifogre/ogre_nif_loader.hpp
@@ -69,7 +69,7 @@ typedef std::vector< std::pair<std::string,std::string> > MeshPairList;
  */
 class NIFLoader
 {
-    static MeshPairList load(std::string name, std::string skelName, const std::string &group);
+    static MeshPairList load(std::string name, std::string skelName, const std::string &group, Ogre::Vector3 *lightPos=NULL);
 
 public:
     static EntityList createEntities(Ogre::Entity *parent, const std::string &bonename,
@@ -80,6 +80,7 @@ public:
     static EntityList createEntities(Ogre::SceneNode *parent,
                                      TextKeyMap *textkeys,
                                      const std::string &name,
+                                     Ogre::Vector3 *lightPos=NULL,
                                      const std::string &group="General");
 };
 


### PR DESCRIPTION
Feature 367, Lights that behave more like original morrowind implementation
Calculates the offsets inside the mesh needed for correct placement of the lights from the nif files (if available) and uses them.
I'm just pushing them through the whole chain from reading the nif file to adding the light. For the future, we'll need some more unified structure that also keeps track of things like smoke, flames, etc.
