### PR TITLE
fix for loading screen break in pull request #514

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -164,9 +164,6 @@ void OMW::Engine::loadBSA()
         dataDirectory = iter->string();
         std::cout << "Data dir " << dataDirectory << std::endl;
         Bsa::addDir(dataDirectory, mFSStrict);
-
-        // Workaround until resource listing capabilities are added to DirArchive, we need those to list available splash screens
-        addResourcesDirectory (dataDirectory);
     }
 }
 

--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -214,27 +214,14 @@ namespace MWGui
     void LoadingScreen::changeWallpaper ()
     {
         if (mResources.isNull ())
-        {
-            mResources = Ogre::StringVectorPtr (new Ogre::StringVector);
-
-            Ogre::StringVectorPtr resources = Ogre::ResourceGroupManager::getSingleton ().listResourceNames ("General", false);
-            for (Ogre::StringVector::const_iterator it = resources->begin(); it != resources->end(); ++it)
-            {
-                if (it->size() < 6)
-                    continue;
-                std::string start = it->substr(0, 6);
-                boost::to_lower(start);
-
-                if (start == "splash")
-                    mResources->push_back (*it);
-            }
-        }
+            mResources = Ogre::ResourceGroupManager::getSingleton ().findResourceNames ("General", "Splash_*.tga");
 
         if (mResources->size())
         {
-            std::string randomSplash = mResources->at (rand() % mResources->size());
+            std::string const & randomSplash = mResources->at (rand() % mResources->size());
 
             Ogre::TexturePtr tex = Ogre::TextureManager::getSingleton ().load (randomSplash, "General");
+
             mBackgroundImage->setImageTexture (randomSplash);
         }
         else


### PR DESCRIPTION
This patch fills out the implementation of the custom archives to allow listing all files, and file searches using patterns. The loading screen is updated to search of the files it needs instead of listing all of them, and then filtering on its own.
