### PR TITLE
Container scripts

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -45,6 +45,7 @@ namespace MWWorld
     class Ptr;
     class TimeStamp;
     class ESMStore;
+    class RefData;
 }
 
 namespace MWBase
@@ -137,6 +138,9 @@ namespace MWBase
             virtual std::vector<std::string> getGlobals () const = 0;
 
             virtual std::string getCurrentCellName() const = 0;
+
+            virtual void removeRefScript (MWWorld::RefData *ref) = 0;
+            //< Remove the script attached to ref from mLocalScripts
 
             virtual MWWorld::Ptr getPtr (const std::string& name, bool activeOnly) = 0;
             ///< Return a pointer to a liveCellRef with the given name.

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -74,7 +74,7 @@ bool MWWorld::ContainerStore::stacks(const Ptr& ptr1, const Ptr& ptr2)
 
 MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& ptr)
 {
-    MWWorld::ContainerStoreIterator it = realAdd(ptr);
+    MWWorld::ContainerStoreIterator it = addImp(ptr);
     MWWorld::Ptr item = *it;
 
     std::string script = MWWorld::Class::get(item).getScript(item);
@@ -97,7 +97,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& ptr)
     return it;
 }
 
-MWWorld::ContainerStoreIterator MWWorld::ContainerStore::realAdd (const Ptr& ptr)
+MWWorld::ContainerStoreIterator MWWorld::ContainerStore::addImp (const Ptr& ptr)
 {
     int type = getType(ptr);
 
@@ -189,7 +189,7 @@ void MWWorld::ContainerStore::fill (const ESM::InventoryList& items, const MWWor
         }
 
         ref.getPtr().getRefData().setCount (std::abs(iter->mCount)); /// \todo implement item restocking (indicated by negative count)
-        realAdd (ref.getPtr());
+        addImp (ref.getPtr());
     }
 
     flagAsModified();

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -90,6 +90,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& ptr)
             cell = player.getCell();
 
         item.mCell = cell;
+        item.mContainerStore = 0;
         MWBase::Environment::get().getWorld()->getLocalScripts().add(script, item);
     }
 

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -52,6 +52,7 @@ namespace MWWorld
             int mStateId;
             mutable float mCachedWeight;
             mutable bool mWeightUpToDate;
+            ContainerStoreIterator realAdd (const Ptr& ptr);
 
         public:
 

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -52,7 +52,7 @@ namespace MWWorld
             int mStateId;
             mutable float mCachedWeight;
             mutable bool mWeightUpToDate;
-            ContainerStoreIterator realAdd (const Ptr& ptr);
+            ContainerStoreIterator addImp (const Ptr& ptr);
 
         public:
 

--- a/apps/openmw/mwworld/localscripts.cpp
+++ b/apps/openmw/mwworld/localscripts.cpp
@@ -3,6 +3,10 @@
 #include "esmstore.hpp"
 #include "cellstore.hpp"
 
+#include "class.hpp"
+#include "containerstore.hpp"
+
+
 namespace
 {
     template<typename T>
@@ -16,6 +20,32 @@ namespace
             if (!iter->mBase->mScript.empty() && iter->mData.getCount())
             {
                 localScripts.add (iter->mBase->mScript, MWWorld::Ptr (&*iter, cell));
+            }
+        }
+    }
+
+    // Adds scripts for items in containers (containers/npcs/creatures)
+    template<typename T>
+    void listCellScriptsCont (MWWorld::LocalScripts& localScripts,
+        MWWorld::CellRefList<T>& cellRefList,  MWWorld::Ptr::CellStore *cell)
+    {
+        for (typename MWWorld::CellRefList<T>::List::iterator iter (
+            cellRefList.mList.begin());
+            iter!=cellRefList.mList.end(); ++iter)
+        {
+           
+            MWWorld::Ptr containerPtr (&*iter, cell); 
+            
+            MWWorld::ContainerStore& container = MWWorld::Class::get(containerPtr).getContainerStore(containerPtr);
+            for(MWWorld::ContainerStoreIterator it3 = container.begin(); it3 != container.end(); ++it3)
+            {
+                std::string script = MWWorld::Class::get(*it3).getScript(*it3);
+                if(script != "")
+                {
+                    MWWorld::Ptr item = *it3;
+                    item.mCell = cell;
+                    localScripts.add (script, item);
+                }
             }
         }
     }
@@ -78,13 +108,16 @@ void MWWorld::LocalScripts::addCell (Ptr::CellStore *cell)
     listCellScripts (*this, cell->mBooks, cell);
     listCellScripts (*this, cell->mClothes, cell);
     listCellScripts (*this, cell->mContainers, cell);
+    listCellScriptsCont (*this, cell->mContainers, cell);
     listCellScripts (*this, cell->mCreatures, cell);
+    listCellScriptsCont (*this, cell->mCreatures, cell);
     listCellScripts (*this, cell->mDoors, cell);
     listCellScripts (*this, cell->mIngreds, cell);
     listCellScripts (*this, cell->mLights, cell);
     listCellScripts (*this, cell->mLockpicks, cell);
     listCellScripts (*this, cell->mMiscItems, cell);
     listCellScripts (*this, cell->mNpcs, cell);
+    listCellScriptsCont (*this, cell->mNpcs, cell);
     listCellScripts (*this, cell->mProbes, cell);
     listCellScripts (*this, cell->mRepairs, cell);
     listCellScripts (*this, cell->mWeapons, cell);

--- a/apps/openmw/mwworld/localscripts.cpp
+++ b/apps/openmw/mwworld/localscripts.cpp
@@ -134,7 +134,7 @@ void MWWorld::LocalScripts::clearCell (Ptr::CellStore *cell)
 
     while (iter!=mScripts.end())
     {
-        if (iter->second.getCell()==cell)
+        if (iter->second.mCell==cell)
         {
             if (iter==mIter)
                ++mIter;

--- a/apps/openmw/mwworld/localscripts.cpp
+++ b/apps/openmw/mwworld/localscripts.cpp
@@ -146,6 +146,20 @@ void MWWorld::LocalScripts::clearCell (Ptr::CellStore *cell)
     }
 }
 
+void MWWorld::LocalScripts::remove (RefData *ref)
+{
+    for (std::list<std::pair<std::string, Ptr> >::iterator iter = mScripts.begin();
+        iter!=mScripts.end(); ++iter)
+        if (&(iter->second.getRefData()) == ref)
+        {
+            if (iter==mIter)
+                ++mIter;
+
+            mScripts.erase (iter);
+            break;
+        }
+}
+
 void MWWorld::LocalScripts::remove (const Ptr& ptr)
 {
     for (std::list<std::pair<std::string, Ptr> >::iterator iter = mScripts.begin();

--- a/apps/openmw/mwworld/localscripts.hpp
+++ b/apps/openmw/mwworld/localscripts.hpp
@@ -10,6 +10,7 @@ namespace MWWorld
 {
     struct ESMStore;
     class CellStore;
+    class RefData;
 
     /// \brief List of active local scripts
     class LocalScripts
@@ -47,6 +48,8 @@ namespace MWWorld
 
             void clearCell (CellStore *cell);
             ///< Remove all scripts belonging to \a cell.
+            
+            void remove (RefData *ref);
 
             void remove (const Ptr& ptr);
             ///< Remove script for given reference (ignored if reference does not have a scirpt listed).

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -74,7 +74,7 @@ namespace MWWorld
 
             bool isInCell() const
             {
-                return (mCell != 0);
+                return (mContainerStore == 0);
             }
 
             void setContainerStore (ContainerStore *store);

--- a/apps/openmw/mwworld/refdata.cpp
+++ b/apps/openmw/mwworld/refdata.cpp
@@ -6,6 +6,9 @@
 #include "customdata.hpp"
 #include "cellstore.hpp"
 
+#include "../mwbase/environment.hpp"
+#include "../mwbase/world.hpp"
+
 namespace MWWorld
 {
     void RefData::copy (const RefData& refData)
@@ -107,6 +110,9 @@ namespace MWWorld
 
     void RefData::setCount (int count)
     {
+        if(count == 0)
+            MWBase::Environment::get().getWorld()->removeRefScript(this);
+        
         mCount = count;
     }
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -341,6 +341,11 @@ namespace MWWorld
         return name;
     }
 
+    void World::removeRefScript (MWWorld::RefData *ref)
+    {
+        mLocalScripts.remove (ref);
+    }
+
     Ptr World::getPtr (const std::string& name, bool activeOnly)
     {
         // the player is always in an active cell.

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -406,6 +406,24 @@ namespace MWWorld
         if (!reference.getRefData().isEnabled())
         {
             reference.getRefData().enable();
+            
+            /* run scripts on container contents */
+            if( reference.getTypeName()==typeid (ESM::Container).name() ||
+                reference.getTypeName()==typeid (ESM::NPC).name() ||
+                reference.getTypeName()==typeid (ESM::Creature).name())
+            {
+                MWWorld::ContainerStore& container = MWWorld::Class::get(reference).getContainerStore(reference);
+                for(MWWorld::ContainerStoreIterator it = container.begin(); it != container.end(); ++it)
+                {
+                    std::string script = MWWorld::Class::get(*it).getScript(*it);
+                    if(script != "")
+                    {
+                        MWWorld::Ptr item = *it;
+                        item.mCell = reference.getCell();
+                        mLocalScripts.add (script, item);
+                    }
+                }
+            }
 
             if(mWorldScene->getActiveCells().find (reference.getCell()) != mWorldScene->getActiveCells().end() && reference.getRefData().getCount())
                 mWorldScene->addObjectToScene (reference);
@@ -417,6 +435,23 @@ namespace MWWorld
         if (reference.getRefData().isEnabled())
         {
             reference.getRefData().disable();
+            
+            /* remove scripts on container contents */
+            if( reference.getTypeName()==typeid (ESM::Container).name() ||
+                reference.getTypeName()==typeid (ESM::NPC).name() ||
+                reference.getTypeName()==typeid (ESM::Creature).name())
+            {
+                MWWorld::ContainerStore& container = MWWorld::Class::get(reference).getContainerStore(reference);
+                for(MWWorld::ContainerStoreIterator it = container.begin(); it != container.end(); ++it)
+                {
+                    std::string script = MWWorld::Class::get(*it).getScript(*it);
+                    if(script != "")
+                    {
+                        MWWorld::Ptr item = *it;
+                        mLocalScripts.remove (item);
+                    }
+                }
+            }
 
             if(mWorldScene->getActiveCells().find (reference.getCell())!=mWorldScene->getActiveCells().end() && reference.getRefData().getCount())
                 mWorldScene->removeObjectFromScene (reference);

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -427,8 +427,6 @@ namespace MWWorld
         {
             reference.getRefData().enable();
             
-            addContainerScripts(reference, reference.getCell());
-
             if(mWorldScene->getActiveCells().find (reference.getCell()) != mWorldScene->getActiveCells().end() && reference.getRefData().getCount())
                 mWorldScene->addObjectToScene (reference);
         }
@@ -459,10 +457,6 @@ namespace MWWorld
         {
             reference.getRefData().disable();
             
-            removeContainerScripts(reference);        
-            if(MWWorld::Class::get(reference).getScript(reference) != "")
-                mLocalScripts.remove(reference);
-
             if(mWorldScene->getActiveCells().find (reference.getCell())!=mWorldScene->getActiveCells().end() && reference.getRefData().getCount())
                 mWorldScene->removeObjectFromScene (reference);
         }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -685,6 +685,7 @@ namespace MWWorld
             {
                 mWorldScene->removeObjectFromScene (ptr);
                 mLocalScripts.remove (ptr);
+                removeContainerScripts (ptr);
             }
         }
     }
@@ -698,6 +699,8 @@ namespace MWWorld
         CellStore *currCell = ptr.getCell();
         bool isPlayer = ptr == mPlayer->getPlayer();
         bool haveToMove = mWorldScene->isCellActive(*currCell) || isPlayer;
+        
+        removeContainerScripts(ptr);
 
         if (*currCell != newCell)
         {
@@ -724,6 +727,8 @@ namespace MWWorld
                 {
                     MWWorld::Ptr copy =
                         MWWorld::Class::get(ptr).copyToCell(ptr, newCell);
+
+                    addContainerScripts(copy, &newCell);
 
                     mRendering->moveObjectToCell(copy, vec, currCell);
 
@@ -1333,6 +1338,7 @@ namespace MWWorld
             if (!script.empty()) {
                 mLocalScripts.add(script, dropped);
             }
+            addContainerScripts(dropped, &cell);
         }
     }
 

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -172,6 +172,9 @@ namespace MWWorld
             virtual std::vector<std::string> getGlobals () const;
             
             virtual std::string getCurrentCellName () const;
+            
+            virtual void removeRefScript (MWWorld::RefData *ref);
+            //< Remove the script attached to ref from mLocalScripts
 
             virtual Ptr getPtr (const std::string& name, bool activeOnly);
             ///< Return a pointer to a liveCellRef with the given name.

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -105,6 +105,9 @@ namespace MWWorld
             float getNpcActivationDistance ();
             float getObjectActivationDistance ();
 
+            void removeContainerScripts(const Ptr& reference);
+            void addContainerScripts(const Ptr& reference, Ptr::CellStore* cell);
+
         public:
 
             World (OEngine::Render::OgreRenderer& renderer,


### PR DESCRIPTION
To address issues from the last pull request:

Setting the cell field of the ptrs:
They are never accessed apart from pointer comparison when removing, I can change this if needs be, but any other solution would be messy (maybe adding a second cell pointer called ContainerCell? ).

Moving an object from one cell to another:
I'm not entirely sure what you mean?
How would you do this, because I suspect it would actually work.

Deleted objects in containers:
The objects in the containers are iterated through using a ContainerStoreIterator, which I believe will skip over disabled items.
