### PR TITLE
Dialogue: disposition

### DIFF
--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -100,14 +100,15 @@ namespace MWClass
             }
             else
             {
-                /// \todo do something with mNpdt12 maybe:p
                 for (int i=0; i<8; ++i)
                     data->mCreatureStats.getAttribute (i).set (10);
 
                 for (int i=0; i<3; ++i)
                     data->mCreatureStats.setDynamic (i, 10);
 
-                data->mCreatureStats.setLevel (1);
+                data->mCreatureStats.setLevel(ref->mBase->mNpdt12.mLevel);
+                data->mNpcStats.setBaseDisposition(ref->mBase->mNpdt12.mDisposition);
+                data->mNpcStats.setReputation(ref->mBase->mNpdt12.mReputation);
             }
 
             data->mCreatureStats.setAiSetting (0, ref->mBase->mAiData.mHello);

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -249,11 +249,11 @@ namespace MWDialogue
 
         const ESM::Dialogue& dialogue = *dialogues.find (topic);
 
+        MWGui::DialogueWindow* win = MWBase::Environment::get().getWindowManager()->getDialogueWindow();
+
         if (const ESM::DialInfo *info = filter.search (dialogue, true))
         {
             parseText (info->mResponse);
-
-            MWGui::DialogueWindow* win = MWBase::Environment::get().getWindowManager()->getDialogueWindow();
 
             if (dialogue.mType==ESM::Dialogue::Persuasion)
             {
@@ -277,6 +277,13 @@ namespace MWDialogue
 
             mLastTopic = topic;
             mLastDialogue = *info;
+        }
+        else
+        {
+            // no response found, print a fallback text
+            win->addTitle (topic);
+            win->addText ("…");
+
         }
     }
 

--- a/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
+++ b/apps/openmw/mwdialogue/dialoguemanagerimp.cpp
@@ -139,7 +139,8 @@ namespace MWDialogue
         {
             if(it->mType == ESM::Dialogue::Greeting)
             {
-                if (const ESM::DialInfo *info = filter.search (*it))
+                // Search a response (we do not accept a fallback to "Info refusal" here)
+                if (const ESM::DialInfo *info = filter.search (*it, false))
                 {
                     //initialise the GUI
                     MWBase::Environment::get().getWindowManager()->pushGuiMode(MWGui::GM_Dialogue);
@@ -248,7 +249,7 @@ namespace MWDialogue
 
         const ESM::Dialogue& dialogue = *dialogues.find (topic);
 
-        if (const ESM::DialInfo *info = filter.search (dialogue))
+        if (const ESM::DialInfo *info = filter.search (dialogue, true))
         {
             parseText (info->mResponse);
 
@@ -295,7 +296,7 @@ namespace MWDialogue
         {
             if (iter->mType == ESM::Dialogue::Topic)
             {
-                if (filter.search (*iter))
+                if (filter.responseAvailable (*iter))
                 {
                     std::string lower = Misc::StringUtils::lowerCase(iter->mId);
                     mActorKnownTopics.push_back (lower);
@@ -412,7 +413,7 @@ namespace MWDialogue
                 {
                     Filter filter (mActor, mChoice, mTalkedTo);
 
-                    if (const ESM::DialInfo *info = filter.search (mDialogueMap[mLastTopic]))
+                    if (const ESM::DialInfo *info = filter.search (mDialogueMap[mLastTopic], true))
                     {
                         mChoiceMap.clear();
                         mChoice = -1;

--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -554,7 +554,7 @@ MWDialogue::Filter::Filter (const MWWorld::Ptr& actor, int choice, bool talkedTo
 : mActor (actor), mChoice (choice), mTalkedToPlayer (talkedToPlayer)
 {}
 
-const ESM::DialInfo *MWDialogue::Filter::search (const ESM::Dialogue& dialogue) const
+const ESM::DialInfo *MWDialogue::Filter::search (const ESM::Dialogue& dialogue, const bool fallbackToInfoRefusal) const
 {
     bool infoRefusal = false;
 
@@ -571,7 +571,7 @@ const ESM::DialInfo *MWDialogue::Filter::search (const ESM::Dialogue& dialogue) 
         }
     }
 
-    if (infoRefusal)
+    if (infoRefusal && fallbackToInfoRefusal)
     {
         // No response is valid because of low NPC disposition,
         // search a response in the topic "Info Refusal"
@@ -590,3 +590,14 @@ const ESM::DialInfo *MWDialogue::Filter::search (const ESM::Dialogue& dialogue) 
     return 0;
 }
 
+bool MWDialogue::Filter::responseAvailable (const ESM::Dialogue& dialogue) const
+{
+    for (std::vector<ESM::DialInfo>::const_iterator iter = dialogue.mInfo.begin();
+        iter!=dialogue.mInfo.end(); ++iter)
+    {
+        if (testActor (*iter) && testPlayer (*iter) && testSelectStructs (*iter))
+            return true;
+    }
+
+    return false;
+}

--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -121,6 +121,13 @@ bool MWDialogue::Filter::testSelectStructs (const ESM::DialInfo& info) const
     return true;
 }
 
+bool MWDialogue::Filter::testDisposition (const ESM::DialInfo& info) const
+{
+    int actorDisposition = MWBase::Environment::get().getMechanicsManager()->getDerivedDisposition(mActor);
+
+    return actorDisposition >= info.mData.mDisposition;
+}
+
 bool MWDialogue::Filter::testSelectStruct (const SelectWrapper& select) const
 {
     if (select.isNpcOnly() && mActor.getTypeName()!=typeid (ESM::NPC).name())
@@ -547,17 +554,38 @@ MWDialogue::Filter::Filter (const MWWorld::Ptr& actor, int choice, bool talkedTo
 : mActor (actor), mChoice (choice), mTalkedToPlayer (talkedToPlayer)
 {}
 
-bool MWDialogue::Filter::operator() (const ESM::DialInfo& info) const
-{
-    return testActor (info) && testPlayer (info) && testSelectStructs (info);
-}
-
 const ESM::DialInfo *MWDialogue::Filter::search (const ESM::Dialogue& dialogue) const
 {
+    bool infoRefusal = false;
+
+    // Iterate over topic responses to find a matching one
     for (std::vector<ESM::DialInfo>::const_iterator iter = dialogue.mInfo.begin();
         iter!=dialogue.mInfo.end(); ++iter)
-        if ((*this) (*iter))
-            return &*iter;
+    {
+        if (testActor (*iter) && testPlayer (*iter) && testSelectStructs (*iter))
+        {
+            if (testDisposition (*iter))
+                return &*iter;
+            else
+                infoRefusal = true;
+        }
+    }
+
+    if (infoRefusal)
+    {
+        // No response is valid because of low NPC disposition,
+        // search a response in the topic "Info Refusal"
+
+        const MWWorld::Store<ESM::Dialogue> &dialogues =
+            MWBase::Environment::get().getWorld()->getStore().get<ESM::Dialogue>();
+
+        const ESM::Dialogue& infoRefusalDialogue = *dialogues.find ("Info Refusal");
+
+        for (std::vector<ESM::DialInfo>::const_iterator iter = infoRefusalDialogue.mInfo.begin();
+            iter!=infoRefusalDialogue.mInfo.end(); ++iter)
+            if (testActor (*iter) && testPlayer (*iter) && testSelectStructs (*iter) && testDisposition(*iter))
+                return &*iter;
+    }
 
     return 0;
 }

--- a/apps/openmw/mwdialogue/filter.hpp
+++ b/apps/openmw/mwdialogue/filter.hpp
@@ -18,39 +18,39 @@ namespace MWDialogue
             MWWorld::Ptr mActor;
             int mChoice;
             bool mTalkedToPlayer;
-    
+
             bool testActor (const ESM::DialInfo& info) const;
             ///< Is this the right actor for this \a info?
-    
+
             bool testPlayer (const ESM::DialInfo& info) const;
             ///< Do the player and the cell the player is currently in match \a info?
-    
+
             bool testSelectStructs (const ESM::DialInfo& info) const;
             ///< Are all select structs matching?
-    
+
+            bool testDisposition (const ESM::DialInfo& info) const;
+            ///< Is the actor disposition toward the player high enough?
+
             bool testSelectStruct (const SelectWrapper& select) const;
-    
+
             bool testSelectStructNumeric (const SelectWrapper& select) const;
-            
+
             int getSelectStructInteger (const SelectWrapper& select) const;
-            
+
             bool getSelectStructBoolean (const SelectWrapper& select) const;
-    
+
             int getFactionRank (const MWWorld::Ptr& actor, const std::string& factionId) const;
-            
+
             bool hasFactionRankSkillRequirements (const MWWorld::Ptr& actor, const std::string& factionId,
                 int rank) const;
 
             bool hasFactionRankReputationRequirements (const MWWorld::Ptr& actor, const std::string& factionId,
                 int rank) const;
-    
-        public:
-        
-            Filter (const MWWorld::Ptr& actor, int choice, bool talkedToPlayer);    
 
-            bool operator() (const ESM::DialInfo& info) const;    
-            ///< \return does the dialogue match?
-            
+        public:
+
+            Filter (const MWWorld::Ptr& actor, int choice, bool talkedToPlayer);
+
             const ESM::DialInfo *search (const ESM::Dialogue& dialogue) const;
     };
 }

--- a/apps/openmw/mwdialogue/filter.hpp
+++ b/apps/openmw/mwdialogue/filter.hpp
@@ -51,7 +51,12 @@ namespace MWDialogue
 
             Filter (const MWWorld::Ptr& actor, int choice, bool talkedToPlayer);
 
-            const ESM::DialInfo *search (const ESM::Dialogue& dialogue) const;
+            const ESM::DialInfo *search (const ESM::Dialogue& dialogue, const bool fallbackToInfoRefusal) const;
+            ///< Get a matching response for the requested dialogue.
+            ///  Redirect to "Info Refusal" topic if a response fulfills all conditions but disposition.
+
+            bool responseAvailable (const ESM::Dialogue& dialogue) const;
+            ///< Does a matching response exist? (disposition is ignored for this check)
     };
 }
 

--- a/files/mygui/openmw_font.xml
+++ b/files/mygui/openmw_font.xml
@@ -11,6 +11,7 @@
             <Code range="33 126"/>
             <Code range="192 382"/> <!-- Central and Eastern European languages glyphs -->
             <Code range="1025 1105"/>
+            <Code range="2026"/> <!-- Ellipsis -->
             <Code range="8470"/>
             <Code range="8211"/>   <!-- Minus -->
             <Code range="8216 8217"/> <!-- Single quotes -->


### PR DESCRIPTION
Clicking a topic in the dialogue window can now return a response from the topic "Info refusal" when the NPC's disposition toward the player is not fulfilled.

If no response is found for "Info refusal", a fallback text is displayed. This text is the unicode character for ellipsis (yet present in existing MW dialogues).

Related bugs: [#497](https://bugs.openmw.org/issues/497), [#498](https://bugs.openmw.org/issues/498), [#500](https://bugs.openmw.org/issues/500)
