### PR TITLE
Importer

### DIFF
--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -827,7 +827,7 @@ void MwIniImporter::importGameFiles(multistrmap &cfg, multistrmap &ini) {
         }
 
         for(std::vector<std::string>::iterator entry = it->second.begin(); entry!=it->second.end(); ++entry) {
-            std::string filetype(entry->substr(entry->length()-4, 3));
+            std::string filetype(entry->substr(entry->length()-3));
             Misc::StringUtils::toLower(filetype);
 
             if(filetype.compare("esm") == 0) {

--- a/apps/mwiniimporter/importer.cpp
+++ b/apps/mwiniimporter/importer.cpp
@@ -777,6 +777,39 @@ void MwIniImporter::insertMultistrmap(multistrmap &cfg, std::string key, std::st
     cfg[key].push_back(value);
 }
 
+void MwIniImporter::importArchives(multistrmap &cfg, multistrmap &ini) {
+    std::vector<std::string> archives;
+    std::string baseArchive("Archives:Archive ");
+    std::string archive;
+
+    // Search archives listed in ini file
+    multistrmap::iterator it = ini.begin();
+    for(int i=0; it != ini.end(); i++) {
+        archive = baseArchive;
+        archive.append(this->numberToString(i));
+
+        it = ini.find(archive);
+        if(it == ini.end()) {
+            break;
+        }
+
+        for(std::vector<std::string>::iterator entry = it->second.begin(); entry!=it->second.end(); ++entry) {
+            archives.push_back(*entry);
+        }
+    }
+
+    cfg.erase("fallback-archive");
+    cfg.insert( std::make_pair<std::string, std::vector<std::string> > ("fallback-archive", std::vector<std::string>()));
+
+    // Add Morrowind.bsa by default, since Vanilla loads this archive even if it
+    // does not appears in the ini file
+    cfg["fallback-archive"].push_back("Morrowind.bsa");
+
+    for(std::vector<std::string>::iterator it=archives.begin(); it!=archives.end(); ++it) {
+        cfg["fallback-archive"].push_back(*it);
+    }
+}
+
 void MwIniImporter::importGameFiles(multistrmap &cfg, multistrmap &ini) {
     std::vector<std::string> esmFiles;
     std::vector<std::string> espFiles;

--- a/apps/mwiniimporter/importer.hpp
+++ b/apps/mwiniimporter/importer.hpp
@@ -23,6 +23,7 @@ class MwIniImporter {
     void    merge(multistrmap &cfg, multistrmap &ini);
     void    mergeFallback(multistrmap &cfg, multistrmap &ini);
     void    importGameFiles(multistrmap &cfg, multistrmap &ini);
+    void    importArchives(multistrmap &cfg, multistrmap &ini);
     void    writeToFile(boost::iostreams::stream<boost::iostreams::file_sink> &out, multistrmap &cfg);
     
   private:

--- a/apps/mwiniimporter/main.cpp
+++ b/apps/mwiniimporter/main.cpp
@@ -18,6 +18,7 @@ int main(int argc, char *argv[]) {
         ("cfg,c", bpo::value<std::string>(), "openmw.cfg file")
         ("output,o", bpo::value<std::string>()->default_value(""), "openmw.cfg file")
         ("game-files,g", "import esm and esp files")
+        ("no-archives,A", "disable bsa archives import")
         ("encoding,e", bpo::value<std::string>()-> default_value("win1252"),
             "Character encoding used in OpenMW game messages:\n"
             "\n\twin1250 - Central and Eastern European such as Polish, Czech, Slovak, Hungarian, Slovene, Bosnian, Croatian, Serbian (Latin script), Romanian and Albanian languages\n"
@@ -74,6 +75,10 @@ int main(int argc, char *argv[]) {
 
     if(vm.count("game-files")) {
         importer.importGameFiles(cfg, ini);
+    }
+
+    if(!vm.count("no-archives")) {
+        importer.importArchives(cfg, ini);
     }
 
     std::cout << "write to: " << outputFile << std::endl;


### PR DESCRIPTION
Add archives to the settings imported.
Archive are imported by default. It is possible to bypass this by running the importer with --no-archives command line option.
The name of the config file entries for BSA archives is "fallback-archive".

The second commit fix a problem with game file importing due to my previous changes.
