### PR TITLE
Pinnable windows

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -30,7 +30,7 @@ add_openmw_dir (mwgui
     formatting inventorywindow container hud countdialog tradewindow settingswindow
     confirmationdialog alchemywindow referenceinterface spellwindow mainmenu quickkeysmenu
     itemselection spellbuyingwindow loadingscreen levelupdialog waitdialog spellcreationdialog
-    enchantingdialog trainingwindow travelwindow imagebutton
+    enchantingdialog trainingwindow travelwindow imagebutton exposedwindow
     )
 
 add_openmw_dir (mwdialogue

--- a/apps/openmw/mwgui/exposedwindow.cpp
+++ b/apps/openmw/mwgui/exposedwindow.cpp
@@ -1,0 +1,26 @@
+#include "exposedwindow.hpp"
+
+#include "MyGUI_Window.h"
+
+namespace MWGui
+{
+    MyGUI::VectorWidgetPtr ExposedWindow::getSkinWidgetsByName (const std::string &name)
+    {
+        return MyGUI::Widget::getSkinWidgetsByName (name);
+    }
+
+    MyGUI::Widget* ExposedWindow::getSkinWidget(const std::string & _name, bool _throw)
+    {
+        MyGUI::VectorWidgetPtr widgets = getSkinWidgetsByName (_name);
+
+        if (widgets.empty())
+        {
+            MYGUI_ASSERT( ! _throw, "widget name '" << _name << "' not found in skin of layout '" << getName() << "'");
+            return nullptr;
+        }
+        else
+        {
+            return widgets[0];
+        }
+    }
+}

--- a/apps/openmw/mwgui/exposedwindow.hpp
+++ b/apps/openmw/mwgui/exposedwindow.hpp
@@ -1,0 +1,26 @@
+#ifndef MWGUI_EXPOSEDWINDOW_H
+#define MWGUI_EXPOSEDWINDOW_H
+
+#include "MyGUI_Window.h"
+
+namespace MWGui
+{
+
+    /**
+     * @brief subclass to provide access to some Widget internals.
+     */
+    class ExposedWindow : public MyGUI::Window
+    {
+        MYGUI_RTTI_DERIVED(ExposedWindow)
+
+    public:
+        MyGUI::VectorWidgetPtr getSkinWidgetsByName (const std::string &name);
+
+        MyGUI::Widget* getSkinWidget(const std::string & _name, bool _throw = true);
+        ///< Get a widget defined in the inner skin of this window.
+    };
+
+}
+
+#endif
+

--- a/apps/openmw/mwgui/window_pinnable_base.cpp
+++ b/apps/openmw/mwgui/window_pinnable_base.cpp
@@ -9,26 +9,20 @@ using namespace MWGui;
 WindowPinnableBase::WindowPinnableBase(const std::string& parLayout, MWBase::WindowManager& parWindowManager)
   : WindowBase(parLayout, parWindowManager), mPinned(false), mVisible(false)
 {
-    MyGUI::WindowPtr t = static_cast<MyGUI::WindowPtr>(mMainWidget);
-    t->eventWindowButtonPressed += MyGUI::newDelegate(this, &WindowPinnableBase::onWindowButtonPressed);
-
     ExposedWindow* window = static_cast<ExposedWindow*>(mMainWidget);
     mPinButton = window->getSkinWidget ("Button");
+
+    mPinButton->eventMouseButtonClick += MyGUI::newDelegate(this, &WindowPinnableBase::onPinButtonClicked);
 }
 
-void WindowPinnableBase::onWindowButtonPressed(MyGUI::Window* sender, const std::string& eventName)
+void WindowPinnableBase::onPinButtonClicked(MyGUI::Widget* _sender)
 {
-    if ("PinToggle" == eventName)
-    {
-        mPinned = !mPinned;
+    mPinned = !mPinned;
 
-        if (mPinned)
-            mPinButton->changeWidgetSkin ("PinDown");
-        else
-            mPinButton->changeWidgetSkin ("PinUp");
+    if (mPinned)
+        mPinButton->changeWidgetSkin ("PinDown");
+    else
+        mPinButton->changeWidgetSkin ("PinUp");
 
-        onPinToggled();
-    }
-
-    eventDone(this);
+    onPinToggled();
 }

--- a/apps/openmw/mwgui/window_pinnable_base.cpp
+++ b/apps/openmw/mwgui/window_pinnable_base.cpp
@@ -2,6 +2,8 @@
 
 #include "../mwbase/windowmanager.hpp"
 
+#include "exposedwindow.hpp"
+
 using namespace MWGui;
 
 WindowPinnableBase::WindowPinnableBase(const std::string& parLayout, MWBase::WindowManager& parWindowManager)
@@ -9,6 +11,9 @@ WindowPinnableBase::WindowPinnableBase(const std::string& parLayout, MWBase::Win
 {
     MyGUI::WindowPtr t = static_cast<MyGUI::WindowPtr>(mMainWidget);
     t->eventWindowButtonPressed += MyGUI::newDelegate(this, &WindowPinnableBase::onWindowButtonPressed);
+
+    ExposedWindow* window = static_cast<ExposedWindow*>(mMainWidget);
+    mPinButton = window->getSkinWidget ("Button");
 }
 
 void WindowPinnableBase::onWindowButtonPressed(MyGUI::Window* sender, const std::string& eventName)
@@ -16,6 +21,12 @@ void WindowPinnableBase::onWindowButtonPressed(MyGUI::Window* sender, const std:
     if ("PinToggle" == eventName)
     {
         mPinned = !mPinned;
+
+        if (mPinned)
+            mPinButton->changeWidgetSkin ("PinDown");
+        else
+            mPinButton->changeWidgetSkin ("PinUp");
+
         onPinToggled();
     }
 

--- a/apps/openmw/mwgui/window_pinnable_base.cpp
+++ b/apps/openmw/mwgui/window_pinnable_base.cpp
@@ -11,16 +11,6 @@ WindowPinnableBase::WindowPinnableBase(const std::string& parLayout, MWBase::Win
     t->eventWindowButtonPressed += MyGUI::newDelegate(this, &WindowPinnableBase::onWindowButtonPressed);
 }
 
-void WindowPinnableBase::setVisible(bool b)
-{
-    // Pinned windows can not be hidden
-    if (mPinned && !b)
-        return;
-
-    WindowBase::setVisible(b);
-    mVisible = b;
-}
-
 void WindowPinnableBase::onWindowButtonPressed(MyGUI::Window* sender, const std::string& eventName)
 {
     if ("PinToggle" == eventName)

--- a/apps/openmw/mwgui/window_pinnable_base.hpp
+++ b/apps/openmw/mwgui/window_pinnable_base.hpp
@@ -11,7 +11,6 @@ namespace MWGui
     {
     public:
         WindowPinnableBase(const std::string& parLayout, MWBase::WindowManager& parWindowManager);
-        void setVisible(bool b);
         bool pinned() { return mPinned; }
 
     private:

--- a/apps/openmw/mwgui/window_pinnable_base.hpp
+++ b/apps/openmw/mwgui/window_pinnable_base.hpp
@@ -19,6 +19,7 @@ namespace MWGui
     protected:
         virtual void onPinToggled() = 0;
 
+        MyGUI::Widget* mPinButton;
         bool mPinned;
         bool mVisible;
     };

--- a/apps/openmw/mwgui/window_pinnable_base.hpp
+++ b/apps/openmw/mwgui/window_pinnable_base.hpp
@@ -14,7 +14,7 @@ namespace MWGui
         bool pinned() { return mPinned; }
 
     private:
-        void onWindowButtonPressed(MyGUI::Window* sender, const std::string& eventName);
+        void onPinButtonClicked(MyGUI::Widget* _sender);
 
     protected:
         virtual void onPinToggled() = 0;

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -52,6 +52,7 @@
 #include "enchantingdialog.hpp"
 #include "trainingwindow.hpp"
 #include "imagebutton.hpp"
+#include "exposedwindow.hpp"
 
 using namespace MWGui;
 
@@ -127,6 +128,7 @@ WindowManager::WindowManager(
     MyGUI::FactoryManager::getInstance().registerFactory<MWGui::Widgets::AutoSizedTextBox>("Widget");
     MyGUI::FactoryManager::getInstance().registerFactory<MWGui::Widgets::AutoSizedButton>("Widget");
     MyGUI::FactoryManager::getInstance().registerFactory<MWGui::ImageButton>("Widget");
+    MyGUI::FactoryManager::getInstance().registerFactory<MWGui::ExposedWindow>("Widget");
 
     MyGUI::LanguageManager::getInstance().eventRequestTag = MyGUI::newDelegate(this, &WindowManager::onRetrieveTag);
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -310,9 +310,16 @@ void WindowManager::updateVisible()
     setSpellVisibility((mAllowed & GW_Magic) && !mSpellWindow->pinned());
     setHMSVisibility((mAllowed & GW_Stats) && !mStatsWindow->pinned());
 
-    // If in game mode, don't show anything.
+    // If in game mode, show only the pinned windows
     if (gameMode)
+    {
+        mMap->setVisible(mMap->pinned());
+        mStatsWindow->setVisible(mStatsWindow->pinned());
+        mInventoryWindow->setVisible(mInventoryWindow->pinned());
+        mSpellWindow->setVisible(mSpellWindow->pinned());
+
         return;
+    }
 
     GuiMode mode = mGuiModes.back();
 
@@ -327,6 +334,12 @@ void WindowManager::updateVisible()
             mSettingsWindow->setVisible(true);
             break;
         case GM_Console:
+            // Show the pinned windows
+            mMap->setVisible(mMap->pinned());
+            mStatsWindow->setVisible(mStatsWindow->pinned());
+            mInventoryWindow->setVisible(mInventoryWindow->pinned());
+            mSpellWindow->setVisible(mSpellWindow->pinned());
+
             mConsole->enable();
             break;
         case GM_Scroll:

--- a/files/mygui/openmw_inventory_window.layout
+++ b/files/mygui/openmw_inventory_window.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Window_Pinnable" layer="Windows" position="0 0 600 300" name="_Main">
+    <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 600 300" name="_Main">
 
         <Widget type="Widget" skin="" position="0 0 224 223" align="Left Top" name="LeftPane">
 

--- a/files/mygui/openmw_map_window.layout
+++ b/files/mygui/openmw_map_window.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 300" name="_Main">
+    <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 300" name="_Main">
 
         <!-- Local map -->
         <Widget type="ScrollView" skin="MW_MapView" position="0 0 284 264" align="ALIGN_STRETCH" name="LocalMap">

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 600" name="_Main">
+    <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 600" name="_Main">
 
         <!-- Effect box-->
         <Widget type="Widget" skin="MW_Box" position="8 8 268 24" align="Left Top HStretch">

--- a/files/mygui/openmw_stats_window.layout
+++ b/files/mygui/openmw_stats_window.layout
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Window_Pinnable" layer="Windows" position="0 0 500 342" name="_Main">
+    <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 500 342" name="_Main">
 
         <Widget type="Widget" skin="" name="LeftPane" position="0 0 220 342">
 

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -585,9 +585,7 @@
             <Property key="Scale" value = "1 1 0 0"/>
         </Child>
 
-        <Child type="Button" skin="PinUp" offset="232 4 19 19" align="ALIGN_RIGHT ALIGN_TOP" name="Button">
-            <Property key="Event" value="PinToggle"/>
-        </Child>
+        <Child type="Button" skin="PinUp" offset="232 4 19 19" align="ALIGN_RIGHT ALIGN_TOP" name="Button"/>
     </Skin>
 
     <Skin name = "MW_Dialog" size = "256 54">

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -8,16 +8,116 @@
         </BasisSkin>
     </Skin>
 
-    <!-- Define the background for pin button -->
-    <Skin name = "PinUp" size = "16 16" texture = "textures\menu_rightbuttondown_center.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 16 16">
-            <State name="normal" offset = "0 0 16 16"/>
+    <!-- Define the borders for pin button (up) -->
+    <Skin name="PU_B" size="12 2" texture="textures\menu_rightbuttonup_bottom.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 12 2">
+            <State name="normal" offset = "0 0 12 2"/>
         </BasisSkin>
     </Skin>
-    <Skin name = "PinDown" size = "8 8" texture = "transparent.png">
-        <BasisSkin type="MainSkin" offset = "0 0 8 8">
-            <State name="normal" offset = "0 0 8 8"/>
+    <Skin name="PU_BR" size="2 2" texture="textures\menu_rightbuttonup_bottom_right.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 2">
+            <State name="normal" offset = "0 0 2 2"/>
         </BasisSkin>
+    </Skin>
+    <Skin name="PU_R" size="2 12" texture="textures\menu_rightbuttonup_right.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 12">
+            <State name="normal" offset = "0 0 2 12"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PU_TR" size="2 2" texture="textures\menu_rightbuttonup_top_right.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 2">
+            <State name="normal" offset = "0 0 2 2"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PU_T" size="12 2" texture="textures\menu_rightbuttonup_top.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 12 2">
+            <State name="normal" offset = "0 0 12 2"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PU_TL" size="2 2" texture="textures\menu_rightbuttonup_top_left.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 2">
+            <State name="normal" offset = "0 0 2 2"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PU_L" size="2 12" texture="textures\menu_rightbuttonup_left.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 12">
+            <State name="normal" offset = "0 0 2 12"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PU_BL" size="2 2" texture="textures\menu_rightbuttonup_bottom_left.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 2">
+            <State name="normal" offset = "0 0 2 2"/>
+        </BasisSkin>
+    </Skin>
+
+    <!-- Define the borders for pin button (down) -->
+    <Skin name="PD_B" size="12 2" texture="textures\menu_rightbuttondown_bottom.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 12 2">
+            <State name="normal" offset = "0 0 12 2"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PD_BR" size="2 2" texture="textures\menu_rightbuttondown_bottom_right.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 2">
+            <State name="normal" offset = "0 0 2 2"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PD_R" size="2 12" texture="textures\menu_rightbuttondown_right.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 12">
+            <State name="normal" offset = "0 0 2 12"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PD_TR" size="2 2" texture="textures\menu_rightbuttondown_top_right.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 2">
+            <State name="normal" offset = "0 0 2 2"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PD_T" size="12 2" texture="textures\menu_rightbuttondown_top.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 12 2">
+            <State name="normal" offset = "0 0 12 2"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PD_TL" size="2 2" texture="textures\menu_rightbuttondown_top_left.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 2">
+            <State name="normal" offset = "0 0 2 2"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PD_L" size="2 12" texture="textures\menu_rightbuttondown_left.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 12">
+            <State name="normal" offset = "0 0 2 12"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name="PD_BL" size="2 2" texture="textures\menu_rightbuttondown_bottom_left.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 2 2">
+            <State name="normal" offset = "0 0 2 2"/>
+        </BasisSkin>
+    </Skin>
+
+    <!-- Define the pin button skin -->
+    <Skin name = "PinUp" size = "19 19" texture="textures\menu_rightbuttonup_center.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 19 19">
+            <State name="normal" offset = "0 0 19 19"/>
+        </BasisSkin>
+        <Child type="Widget" skin="PU_B"  offset="2 17 15 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PU_BR" offset="17 17 2 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+				<Child type="Widget" skin="PU_R"  offset="17 2 2 15" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PU_TR" offset="17 0 2 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PU_T"  offset="2 0 15 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PU_TL" offset="0 0 2 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PU_L"  offset="0 2 2 15" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PU_BL" offset="0 17 2 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+    </Skin>
+    <Skin name = "PinDown" size = "19 19" texture="textures\menu_rightbuttondown_center.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 19 19">
+            <State name="normal" offset = "0 0 19 19"/>
+        </BasisSkin>
+        <Child type="Widget" skin="PD_B"  offset="2 17 15 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PD_BR" offset="17 17 2 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+				<Child type="Widget" skin="PD_R"  offset="17 2 2 15" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PD_TR" offset="17 0 2 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PD_T"  offset="2 0 15 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PD_TL" offset="0 0 2 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PD_L"  offset="0 2 2 15" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
+        <Child type="Widget" skin="PD_BL" offset="0 17 2 2" align="ALIGN_HSTRETCH ALIGN_VSTRETCH"/>
     </Skin>
 
     <!-- Defines a pure black background -->
@@ -485,7 +585,7 @@
             <Property key="Scale" value = "1 1 0 0"/>
         </Child>
 
-        <Child type="Button" skin="PinUp" offset="230 4 21 19" align="ALIGN_RIGHT ALIGN_TOP" name="Button">
+        <Child type="Button" skin="PinUp" offset="232 4 19 19" align="ALIGN_RIGHT ALIGN_TOP" name="Button">
             <Property key="Event" value="PinToggle"/>
         </Child>
     </Skin>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -8,6 +8,18 @@
         </BasisSkin>
     </Skin>
 
+    <!-- Define the background for pin button -->
+    <Skin name = "PinUp" size = "16 16" texture = "textures\menu_rightbuttondown_center.dds">
+        <BasisSkin type="MainSkin" offset = "0 0 16 16">
+            <State name="normal" offset = "0 0 16 16"/>
+        </BasisSkin>
+    </Skin>
+    <Skin name = "PinDown" size = "8 8" texture = "transparent.png">
+        <BasisSkin type="MainSkin" offset = "0 0 8 8">
+            <State name="normal" offset = "0 0 8 8"/>
+        </BasisSkin>
+    </Skin>
+
     <!-- Defines a pure black background -->
     <Skin name = "DialogBG" size = "8 8" texture = "black.png">
         <BasisSkin type="MainSkin" offset = "0 0 8 8">
@@ -473,7 +485,7 @@
             <Property key="Scale" value = "1 1 0 0"/>
         </Child>
 
-        <Child type="Button" skin="BlackBG" offset="230 4 21 19" align="ALIGN_RIGHT ALIGN_TOP" name="Button">
+        <Child type="Button" skin="PinUp" offset="230 4 21 19" align="ALIGN_RIGHT ALIGN_TOP" name="Button">
             <Property key="Event" value="PinToggle"/>
         </Child>
     </Skin>


### PR DESCRIPTION
Fix https://bugs.openmw.org/issues/530 and a little thing spotted during my tests.  

Speaking of the issue: I added a function 'getSkinWidget' in OEngine::GUI::Layout for consistency. This function is similar to the existing 'getWidget' but allow to access different GUI widgets (those defined in the skin instead of those defined in the layout).
Is it okay to modify OpenEngine or is it preferable to move this in MWGui?

Now about the other fix: the first commit changes the display conditions of pinned windows, which were displayed when the menu is shown and during dialogue and trading. With this commit, pinned windows are displayed during game, in console mode and (of course) in inventory mode. This differs from vanilla, as they were also displayed behind the rest window and the "quick keys" window. These two windows were modals. Since interacting with pinned windows was impossible, I think hiding them is functionally equivalent.
