### PR TITLE
Created a functioning "abort" button for the operation widget.

### DIFF
--- a/apps/opencs/view/doc/operation.cpp
+++ b/apps/opencs/view/doc/operation.cpp
@@ -1,8 +1,11 @@
 
-#include "operation.hpp"
-
 #include <sstream>
 
+#include <QProgressBar>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+#include "operation.hpp"
 #include "../../model/doc/document.hpp"
 
 void CSVDoc::Operation::updateLabel (int threads)
@@ -28,12 +31,20 @@ void CSVDoc::Operation::updateLabel (int threads)
             stream << name << " (%p%)";
         }
 
-        setFormat (stream.str().c_str());
+        mProgressBar->setFormat (stream.str().c_str());
     }
 }
 
 CSVDoc::Operation::Operation (int type) : mType (type), mStalling (false)
 {
+    mProgressBar = new QProgressBar ();
+    mAbortButton = new QPushButton ("Abort");
+    mVBoxLayout = new QVBoxLayout();
+
+    mVBoxLayout->addWidget (mProgressBar);
+    mVBoxLayout->addWidget (mAbortButton);
+
+    connect (mAbortButton, SIGNAL (clicked()), this, SLOT (abortOperation()));
     /// \todo Add a cancel button or a pop up menu with a cancel item
 
     updateLabel();
@@ -44,11 +55,21 @@ CSVDoc::Operation::Operation (int type) : mType (type), mStalling (false)
 void CSVDoc::Operation::setProgress (int current, int max, int threads)
 {
     updateLabel (threads);
-    setRange (0, max);
-    setValue (current);
+    mProgressBar->setRange (0, max);
+    mProgressBar->setValue (current);
 }
 
 int CSVDoc::Operation::getType() const
 {
     return mType;
+}
+
+QVBoxLayout *CSVDoc::Operation::getLayout() const
+{
+    return mVBoxLayout;
+}
+
+void CSVDoc::Operation::abortOperation()
+{
+    emit abortOperation (mType);
 }

--- a/apps/opencs/view/doc/operation.hpp
+++ b/apps/opencs/view/doc/operation.hpp
@@ -1,16 +1,23 @@
 #ifndef CSV_DOC_OPERATION_H
 #define CSV_DOC_OPERATION_H
 
-#include <QProgressBar>
+#include <QObject>
+
+class QProgressBar;
+class QPushButton;
+class QVBoxLayout;
 
 namespace CSVDoc
 {
-    class Operation : public QProgressBar
+    class Operation: public QObject
     {
             Q_OBJECT
 
             int mType;
             bool mStalling;
+            QProgressBar *mProgressBar;
+            QPushButton  *mAbortButton;
+            QVBoxLayout  *mVBoxLayout;
 
             // not implemented
             Operation (const Operation&);
@@ -25,6 +32,16 @@ namespace CSVDoc
             void setProgress (int current, int max, int threads);
 
             int getType() const;
+
+            QVBoxLayout* getLayout() const;
+
+        signals:
+
+            void abortOperation (int type);
+
+        private slots:
+
+            void abortOperation ();
     };
 }
 

--- a/apps/opencs/view/doc/operations.cpp
+++ b/apps/opencs/view/doc/operations.cpp
@@ -10,13 +10,6 @@ CSVDoc::Operations::Operations()
     /// \todo make widget height fixed (exactly the height required to display all operations)
 
     setFeatures (QDockWidget::NoDockWidgetFeatures);
-
-    QWidget *widget = new QWidget;
-    setWidget (widget);
-
-    mLayout = new QVBoxLayout;
-
-    widget->setLayout (mLayout);
 }
 
 void CSVDoc::Operations::setProgress (int current, int max, int type, int threads)
@@ -30,7 +23,13 @@ void CSVDoc::Operations::setProgress (int current, int max, int type, int thread
 
     Operation *operation = new Operation (type);
 
-    mLayout->addWidget (operation);
+    connect (operation, SIGNAL (abortOperation (int)), this, SIGNAL (abortOperation (int)));
+
+    QWidget *widget = new QWidget;
+    setWidget (widget);
+
+    widget->setLayout (operation->getLayout());
+
     mOperations.push_back (operation);
     operation->setProgress (current, max, threads);
 }
@@ -40,6 +39,8 @@ void CSVDoc::Operations::quitOperation (int type)
     for (std::vector<Operation *>::iterator iter (mOperations.begin()); iter!=mOperations.end(); ++iter)
         if ((*iter)->getType()==type)
         {
+            setWidget (0);
+
             delete *iter;
             mOperations.erase (iter);
             break;

--- a/apps/opencs/view/doc/operations.hpp
+++ b/apps/opencs/view/doc/operations.hpp
@@ -31,6 +31,10 @@ namespace CSVDoc
 
             void quitOperation (int type);
             ///< Calling this function for an operation that is not running is a no-op.
+
+        signals:
+
+            void abortOperation (int type);
     };
 }
 

--- a/apps/opencs/view/doc/startup.cpp
+++ b/apps/opencs/view/doc/startup.cpp
@@ -1,0 +1,20 @@
+
+#include "startup.hpp"
+
+#include <QPushButton>
+#include <QHBoxLayout>
+
+CSVDoc::StartupDialogue::StartupDialogue()
+{
+    QHBoxLayout *layout = new QHBoxLayout (this);
+
+    QPushButton *createDocument = new QPushButton ("new", this);
+    connect (createDocument, SIGNAL (clicked()), this, SIGNAL (createDocument()));
+    layout->addWidget (createDocument);
+
+    QPushButton *loadDocument = new QPushButton ("load", this);
+    connect (loadDocument, SIGNAL (clicked()), this, SIGNAL (loadDocument()));
+    layout->addWidget (loadDocument);
+
+    setLayout (layout);
+}

--- a/apps/opencs/view/doc/startup.hpp
+++ b/apps/opencs/view/doc/startup.hpp
@@ -1,0 +1,24 @@
+#ifndef CSV_DOC_STARTUP_H
+#define CSV_DOC_STARTUP_H
+
+#include <QWidget>
+
+namespace CSVDoc
+{
+    class StartupDialogue : public QWidget
+    {
+        Q_OBJECT
+
+        public:
+
+            StartupDialogue();
+
+        signals:
+
+            void createDocument();
+
+            void loadDocument();
+    };
+}
+
+#endif

--- a/apps/opencs/view/doc/view.cpp
+++ b/apps/opencs/view/doc/view.cpp
@@ -125,6 +125,8 @@ CSVDoc::View::View (ViewManager& viewManager, CSMDoc::Document *document, int to
 
     CSVWorld::addSubViewFactories (mSubViewFactory);
     CSVTools::addSubViewFactories (mSubViewFactory);
+
+    connect (mOperations, SIGNAL (abortOperation (int)), this, SLOT (abortOperation(int)));
 }
 
 CSVDoc::View::~View()
@@ -213,4 +215,10 @@ void CSVDoc::View::verify()
 void CSVDoc::View::addGlobalsSubView()
 {
     addSubView (CSMWorld::UniversalId::Type_Globals);
+}
+
+void CSVDoc::View::abortOperation (int type)
+{
+    mDocument->abortOperation(type);
+    mOperations->quitOperation(type);
 }

--- a/apps/opencs/view/doc/view.hpp
+++ b/apps/opencs/view/doc/view.hpp
@@ -97,6 +97,8 @@ namespace CSVDoc
             void verify();
 
             void addGlobalsSubView();
+
+            void abortOperation(int type);
     };
 }
 


### PR DESCRIPTION
Redefined "operation" class as a generic "QObject" class to act as a
container for the progress bar and abort button both.

Layout issue with the Abort button - not sure what to do about it.
Perhaps inline with the progress bar?  Maybe reduce to an "X" icon?
