### PR TITLE
Size t warnings v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,6 +529,8 @@ if (WIN32)
         set(WARNINGS "${WARNINGS} /wd${d}")
     endforeach(d)
 
+    set_target_properties(shiny PROPERTIES COMPILE_FLAGS ${WARNINGS})
+    set_target_properties(shiny.OgrePlatform PROPERTIES COMPILE_FLAGS ${WARNINGS})
     set_target_properties(components PROPERTIES COMPILE_FLAGS ${WARNINGS})
     if (BUILD_LAUNCHER)
 		set_target_properties(omwlauncher PROPERTIES COMPILE_FLAGS ${WARNINGS})

--- a/apps/openmw/mwworld/scene.cpp
+++ b/apps/openmw/mwworld/scene.cpp
@@ -25,7 +25,7 @@ namespace
             const MWWorld::Class& class_ =
                 MWWorld::Class::get (MWWorld::Ptr (&*cellRefList.mList.begin(), &cell));
 
-            int numRefs = cellRefList.mList.size();
+            size_t numRefs = cellRefList.mList.size();
             int current = 0;
             for (typename T::List::iterator it = cellRefList.mList.begin();
                 it != cellRefList.mList.end(); it++)

--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -17,7 +17,7 @@ namespace MWWorld
         virtual void setUp() {}
         virtual void listIdentifier(std::vector<std::string> &list) const {}
 
-        virtual int getSize() const = 0;
+        virtual size_t getSize() const = 0;
         virtual void load(ESM::ESMReader &esm, const std::string &id) = 0;
         
         virtual bool eraseStatic(const std::string &id) {return false;}
@@ -158,7 +158,7 @@ namespace MWWorld
             return mShared.end();
         }
 
-        int getSize() const {
+        size_t getSize() const {
             return mShared.size();
         }
 
@@ -269,11 +269,11 @@ namespace MWWorld
             return ptr;
         }
 
-        int getSize() const {
+        size_t getSize() const {
             return mStatic.size();
         }
 
-        int getSize(size_t plugin) const {
+        size_t getSize(size_t plugin) const {
             assert(plugin < mStatic.size());
             return mStatic[plugin].size();
         }
@@ -338,7 +338,7 @@ namespace MWWorld
 
         }
 
-        int getSize() const {
+        size_t getSize() const {
             return mStatic.size();
         }
 
@@ -567,7 +567,7 @@ namespace MWWorld
             return 0;
         }
 
-        int getSize() const {
+        size_t getSize() const {
             return mSharedInt.size() + mSharedExt.size();
         }
 
@@ -701,7 +701,7 @@ namespace MWWorld
             mStatic.back().load(esm);
         }
 
-        int getSize() const {
+        size_t getSize() const {
             return mStatic.size();
         }
 
@@ -930,7 +930,7 @@ namespace MWWorld
             }
         }
 
-        int getSize() const {
+        size_t getSize() const {
             return mStatic.size();
         }
 

--- a/components/esm/esmwriter.cpp
+++ b/components/esm/esmwriter.cpp
@@ -136,15 +136,15 @@ void ESMWriter::writeHNString(const std::string& name, const std::string& data)
     endRecord(name);
 }
 
-void ESMWriter::writeHNString(const std::string& name, const std::string& data, int size)
+void ESMWriter::writeHNString(const std::string& name, const std::string& data, size_t size)
 {
-    assert(static_cast<int> (data.size()) <= size);
+    assert(data.size() <= size);
     startSubRecord(name);
     writeHString(data);
 
-    if (static_cast<int> (data.size()) < size)
+    if (data.size() < size)
     {
-        for (int i = data.size(); i < size; ++i)
+        for (size_t i = data.size(); i < size; ++i)
             write("\0",1);
     }
 
@@ -177,7 +177,7 @@ void ESMWriter::writeName(const std::string& name)
     write(name.c_str(), name.size());
 }
 
-void ESMWriter::write(const char* data, int size)
+void ESMWriter::write(const char* data, size_t size)
 {
     if (count && !m_records.empty())
     {

--- a/components/esm/esmwriter.hpp
+++ b/components/esm/esmwriter.hpp
@@ -16,7 +16,7 @@ class ESMWriter
     {
         std::string name;
         std::streampos position;
-        int size;
+        size_t size;
     };
 
 public:
@@ -35,7 +35,7 @@ public:
     void close();
 
     void writeHNString(const std::string& name, const std::string& data);
-    void writeHNString(const std::string& name, const std::string& data, int size);
+    void writeHNString(const std::string& name, const std::string& data, size_t size);
     void writeHNCString(const std::string& name, const std::string& data)
     {
         startSubRecord(name);
@@ -76,7 +76,7 @@ public:
     }
 
     template<typename T>
-    void writeT(const T& data, int size)
+    void writeT(const T& data, size_t size)
     {
         write((char*)&data, size);
     }
@@ -87,7 +87,7 @@ public:
     void writeHString(const std::string& data);
     void writeHCString(const std::string& data);
     void writeName(const std::string& data);
-    void write(const char* data, int size);
+    void write(const char* data, size_t size);
 
 private:
     std::list<MasterData> m_masters;

--- a/components/to_utf8/to_utf8.cpp
+++ b/components/to_utf8/to_utf8.cpp
@@ -70,7 +70,7 @@ Utf8Encoder::Utf8Encoder(const FromType sourceEncoding):
     }
 }
 
-std::string Utf8Encoder::getUtf8(const char* input, int size)
+std::string Utf8Encoder::getUtf8(const char* input, size_t size)
 {
     // Double check that the input string stops at some point (it might
     // contain zero terminators before this, inside its own data, which
@@ -111,7 +111,7 @@ std::string Utf8Encoder::getUtf8(const char* input, int size)
     return std::string(&mOutput[0], outlen);
 }
 
-std::string Utf8Encoder::getLegacyEnc(const char *input, int size)
+std::string Utf8Encoder::getLegacyEnc(const char *input, size_t size)
 {
     // Double check that the input string stops at some point (it might
     // contain zero terminators before this, inside its own data, which

--- a/components/to_utf8/to_utf8.hpp
+++ b/components/to_utf8/to_utf8.hpp
@@ -27,13 +27,13 @@ namespace ToUTF8
             Utf8Encoder(FromType sourceEncoding);
 
             // Convert to UTF8 from the previously given code page.
-            std::string getUtf8(const char *input, int size);
+            std::string getUtf8(const char *input, size_t size);
             inline std::string getUtf8(const std::string &str)
             {
                 return getUtf8(str.c_str(), str.size());
             }
 
-            std::string getLegacyEnc(const char *input, int size);
+            std::string getLegacyEnc(const char *input, size_t size);
             inline std::string getLegacyEnc(const std::string &str)
             {
                 return getLegacyEnc(str.c_str(), str.size());


### PR DESCRIPTION
superceeds https://github.com/zinnschlag/openmw/pull/585
updated and tested on linux, removes around 7K warnings on windows 64 bit build
