### PR TITLE
Prepare .desktop file for more systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,7 @@ configure_file(${OpenMW_SOURCE_DIR}/files/openmw.cfg
     "${OpenMW_BINARY_DIR}/openmw.cfg.install")
 
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if (NOT WIN32 AND NOT APPLE)
     configure_file(${OpenMW_SOURCE_DIR}/files/openmw.desktop
         "${OpenMW_BINARY_DIR}/openmw.desktop")
 endif()


### PR DESCRIPTION
This brings condition for .desktop file preparation in sync with
condition for its installation.
