### PR TITLE
Do not hide pinned windows during loadings

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -424,6 +424,12 @@ void WindowManager::updateVisible()
             MyGUI::PointerManager::getInstance().setVisible(false);
             break;
         case GM_Loading:
+            // Show the pinned windows
+            mMap->setVisible(mMap->pinned());
+            mStatsWindow->setVisible(mStatsWindow->pinned());
+            mInventoryWindow->setVisible(mInventoryWindow->pinned());
+            mSpellWindow->setVisible(mSpellWindow->pinned());
+
             MyGUI::PointerManager::getInstance().setVisible(false);
             break;
         case GM_Video:


### PR DESCRIPTION
Pinned windows disappears on cell loading and it is a little annoying.
