### PR TITLE
NIF: added NiStencilProperty record handling

### DIFF
--- a/components/nif/nif_file.cpp
+++ b/components/nif/nif_file.cpp
@@ -256,6 +256,7 @@ void NIFFile::parse()
       else if(rec == "NiDitherProperty") { r = new NiDitherProperty; r->recType = RC_NiDitherProperty; }
       else if(rec == "NiWireframeProperty") { r = new NiWireframeProperty; r->recType = RC_NiWireframeProperty; }
       else if(rec == "NiSpecularProperty") { r = new NiSpecularProperty; r->recType = RC_NiSpecularProperty; }
+      else if(rec == "NiStencilProperty") { r = new NiStencilProperty; r->recType = RC_NiStencilProperty; }
 
       // Controllers
       else if(rec == "NiVisController") { r = new NiVisController; r->recType = RC_NiVisController; }

--- a/components/nif/nif_file.hpp
+++ b/components/nif/nif_file.hpp
@@ -158,6 +158,7 @@ public:
     short getShort() { return read_le16(); }
     unsigned short getUShort() { return read_le16(); }
     int getInt() { return read_le32(); }
+    unsigned int getUInt() { return read_le32(); }
     float getFloat() { return read_le32f(); }
     Ogre::Vector2 getVector2()
     {

--- a/components/nif/property.hpp
+++ b/components/nif/property.hpp
@@ -257,9 +257,66 @@ struct S_AlphaProperty
     }
 };
 
+/*
+    Docs taken from:
+    http://niftools.sourceforge.net/doc/nif/NiStencilProperty.html
+ */
+struct S_StencilProperty
+{
+    // Is stencil test enabled?
+    unsigned char enabled;
+
+    /*
+        0   TEST_NEVER
+        1   TEST_LESS
+        2   TEST_EQUAL
+        3   TEST_LESS_EQUAL
+        4   TEST_GREATER
+        5   TEST_NOT_EQUAL
+        6   TEST_GREATER_EQUAL
+        7   TEST_ALWAYS
+     */
+    int compareFunc;
+    unsigned stencilRef;
+    unsigned stencilMask;
+    /*
+        Stencil test fail action, depth test fail action and depth test pass action:
+        0   ACTION_KEEP
+        1   ACTION_ZERO
+        2   ACTION_REPLACE
+        3   ACTION_INCREMENT
+        4   ACTION_DECREMENT
+        5   ACTION_INVERT
+     */
+    int failAction;
+    int zFailAction;
+    int zPassAction;
+    /*
+        Face draw mode:
+        0   DRAW_CCW_OR_BOTH
+        1   DRAW_CCW        [default]
+        2   DRAW_CW
+        3   DRAW_BOTH
+     */
+    int drawMode;
+
+    void read(NIFFile *nif)
+    {
+        enabled = nif->getChar();
+        compareFunc = nif->getInt();
+        stencilRef = nif->getUInt();
+        stencilMask = nif->getUInt();
+        failAction = nif->getInt();
+        zFailAction = nif->getInt();
+        zPassAction = nif->getInt();
+        drawMode = nif->getInt();
+    }
+};
+
 typedef StructPropT<S_AlphaProperty> NiAlphaProperty;
 typedef StructPropT<S_MaterialProperty> NiMaterialProperty;
 typedef StructPropT<S_VertexColorProperty> NiVertexColorProperty;
+typedef StructPropT<S_StencilProperty> NiStencilProperty;
 
 } // Namespace
 #endif

--- a/components/nif/record.hpp
+++ b/components/nif/record.hpp
@@ -48,6 +48,7 @@ enum RecordType
   RC_NiDitherProperty,
   RC_NiWireframeProperty,
   RC_NiSpecularProperty,
+  RC_NiStencilProperty,
   RC_NiVisController,
   RC_NiGeomMorpherController,
   RC_NiKeyframeController,

--- a/components/nifogre/ogre_nif_loader.cpp
+++ b/components/nifogre/ogre_nif_loader.cpp
@@ -586,6 +586,8 @@ static Ogre::String getMaterial(const Nif::NiTriShape *shape, const Ogre::String
             m = static_cast<const Nif::NiMaterialProperty*>(pr);
         else if (pr->recType == Nif::RC_NiAlphaProperty)
             a = static_cast<const Nif::NiAlphaProperty*>(pr);
+        else if (pr->recType == Nif::RC_NiStencilProperty)
+            /* unused */;
         else
             warn("Skipped property type: "+pr->recName);
     }


### PR DESCRIPTION
NiStencilProperty appears in Better Clothes plugin. If it not handled,
some parts of NPCs bodies will be not rendered.

Balmora, square near House Hlaalu quarters:
![bc_before](https://f.cloud.github.com/assets/1856842/202573/2a3ae7fa-8117-11e2-9269-a35c954790a0.png)
![bc_after](https://f.cloud.github.com/assets/1856842/202574/2eb9b70c-8117-11e2-9047-70bcfd0b526f.png)
