### PR TITLE
Store strings count insted of strings lenght.

### DIFF
--- a/components/compiler/literals.cpp
+++ b/components/compiler/literals.cpp
@@ -29,6 +29,11 @@ namespace Compiler
         return size;
     }
 
+    int Literals::getStringCount() const
+    {
+        return mStrings.size();
+    }
+
     void Literals::append (std::vector<Interpreter::Type_Code>& code) const
     {
         for (std::vector<Interpreter::Type_Integer>::const_iterator iter (mIntegers.begin());

--- a/components/compiler/literals.hpp
+++ b/components/compiler/literals.hpp
@@ -26,6 +26,9 @@ namespace Compiler
         
             int getStringSize() const;
             ///< Return size of string block (in bytes).
+
+            int getStringCount() const;
+            ///< Return strings count to check boundaries.
         
             void append (std::vector<Interpreter::Type_Code>& code) const;
             ///< Apepnd literal blocks to code.

--- a/components/compiler/output.cpp
+++ b/components/compiler/output.cpp
@@ -24,8 +24,7 @@ namespace Compiler
         assert (mLiterals.getFloatSize()%4==0);
         code.push_back (static_cast<Interpreter::Type_Code> (mLiterals.getFloatSize()/4));
         
-        assert (mLiterals.getStringSize()%4==0);
-        code.push_back (static_cast<Interpreter::Type_Code> (mLiterals.getStringSize()/4));
+        code.push_back (static_cast<Interpreter::Type_Code> (mLiterals.getStringCount()));
         
         // code
         std::copy (mCode.begin(), mCode.end(), std::back_inserter (code));


### PR DESCRIPTION
It makes assert in "getStringLiteral" a proper boundary check.
Adding new types to scripts and storing them after strings will be a little harder.
