### PR TITLE
additional boost libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ endif()
 # find boost without components so we can use Boost_VERSION
 find_package(Boost REQUIRED)
 
-set(BOOST_COMPONENTS system filesystem program_options thread date_time chrono)
+set(BOOST_COMPONENTS system filesystem program_options thread date_time)
 
 if (Boost_VERSION LESS 104900)
     set(SHINY_USE_WAVE_SYSTEM_INSTALL "TRUE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ endif()
 # find boost without components so we can use Boost_VERSION
 find_package(Boost REQUIRED)
 
-set(BOOST_COMPONENTS system filesystem program_options thread)
+set(BOOST_COMPONENTS system filesystem program_options thread date_time chrono)
 
 if (Boost_VERSION LESS 104900)
     set(SHINY_USE_WAVE_SYSTEM_INSTALL "TRUE")


### PR DESCRIPTION
Added two additional required boost libs to build on windows, one of which is already pulled by other boost lib in Ubuntu but not the other. Let us be consistent.
