### PR TITLE
Load fallback archives listed in openmw.cfg at startup

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -149,16 +149,22 @@ OMW::Engine::~Engine()
     delete mOgre;
 }
 
-// Load all BSA files in data directory.
+// Load BSA files
 
 void OMW::Engine::loadBSA()
 {
-    const Files::MultiDirCollection& bsa = mFileCollections.getCollection (".bsa");
-
-    for (Files::MultiDirCollection::TIter iter(bsa.begin()); iter!=bsa.end(); ++iter)
+    for (std::vector<std::string>::const_iterator archive = mArchives.begin(); archive != mArchives.end(); ++archive)
     {
-        std::cout << "Adding " << iter->second.string() << std::endl;
-        Bsa::addBSA(iter->second.string());
+        if (mFileCollections.doesExist(*archive))
+        {
+            const std::string archivePath = mFileCollections.getPath(*archive).string();
+            std::cout << "Adding BSA archive " << archivePath << std::endl;
+            Bsa::addBSA(archivePath);
+        }
+        else
+        {
+            std::cout << "Archive " << *archive << " not found" << std::endl;
+        }
     }
 
     const Files::PathContainer& dataDirs = mFileCollections.getPaths();
@@ -197,6 +203,11 @@ void OMW::Engine::setDataDirs (const Files::PathContainer& dataDirs)
 {
     mDataDirs = dataDirs;
     mFileCollections = Files::Collections (dataDirs, !mFSStrict);
+}
+
+// Add BSA archive
+void OMW::Engine::addArchive (const std::string& archive) {
+    mArchives.push_back(archive);
 }
 
 // Set resource dir

--- a/apps/openmw/engine.hpp
+++ b/apps/openmw/engine.hpp
@@ -64,6 +64,7 @@ namespace OMW
             ToUTF8::FromType mEncoding;
             ToUTF8::Utf8Encoder* mEncoder;
             Files::PathContainer mDataDirs;
+            std::vector<std::string> mArchives;
             boost::filesystem::path mResDir;
             OEngine::Render::OgreRenderer *mOgre;
             std::string mCellName;
@@ -99,7 +100,7 @@ namespace OMW
             /// add a .zip resource
             void addZipResource (const boost::filesystem::path& path);
 
-            /// Load all BSA files in data directory.
+            /// Load BSA files
             void loadBSA();
 
             void executeLocalScripts();
@@ -125,6 +126,9 @@ namespace OMW
 
             /// Set data dirs
             void setDataDirs(const Files::PathContainer& dataDirs);
+
+            /// Add BSA archive
+            void addArchive(const std::string& archive);
 
             /// Set resource dir
             void setResourceDir(const boost::filesystem::path& parResDir);

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -100,6 +100,9 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
         ("data-local", bpo::value<std::string>()->default_value(""),
             "set local data directory (highest priority)")
 
+        ("fallback-archive", bpo::value<StringsVector>()->default_value(StringsVector(), "fallback-archive")
+            ->multitoken(), "set fallback BSA archives (later archives have higher priority)")
+
         ("resources", bpo::value<std::string>()->default_value("resources"),
             "set resources directory")
 
@@ -200,6 +203,13 @@ bool parseOptions (int argc, char** argv, OMW::Engine& engine, Files::Configurat
     cfgMgr.processPaths(dataDirs);
 
     engine.setDataDirs(dataDirs);
+
+    // fallback archives
+    StringsVector archives = variables["fallback-archive"].as<StringsVector>();
+    for (StringsVector::const_iterator it = archives.begin(); it != archives.end(); it++)
+    {
+        engine.addArchive(*it);
+    }
 
     engine.setResourceDir(variables["resources"].as<std::string>());
 

--- a/components/files/collections.cpp
+++ b/components/files/collections.cpp
@@ -31,6 +31,32 @@ namespace Files
         return iter->second;
     }
 
+    boost::filesystem::path Collections::getPath(const std::string& file) const
+    {
+        for (Files::PathContainer::const_iterator iter = mDirectories.begin();
+             iter != mDirectories.end(); ++iter)
+        {
+            const boost::filesystem::path path = *iter / file;
+            if (boost::filesystem::exists(path))
+                return path.string();
+        }
+
+        throw std::runtime_error ("file " + file + " not found");
+    }
+
+    bool Collections::doesExist(const std::string& file) const
+    {
+        for (Files::PathContainer::const_iterator iter = mDirectories.begin();
+             iter != mDirectories.end(); ++iter)
+        {
+            const boost::filesystem::path path = *iter / file;
+            if (boost::filesystem::exists(path))
+                return true;
+        }
+
+        return false;
+    }
+
     const Files::PathContainer& Collections::getPaths() const
     {
         return mDirectories;

--- a/components/files/collections.hpp
+++ b/components/files/collections.hpp
@@ -19,6 +19,16 @@ namespace Files
             /// leading dot and must be all lower-case.
             const MultiDirCollection& getCollection(const std::string& extension) const;
 
+            boost::filesystem::path getPath(const std::string& file) const;
+            ///< Return full path (including filename) of \a file.
+            ///
+            /// If the file does not exist in any of the collection's
+            /// directories, an exception is thrown. \a file must include the
+            /// extension.
+
+            bool doesExist(const std::string& file) const;
+            ///< \return Does a file with the given name exist?
+
             const Files::PathContainer& getPaths() const;
 
         private:


### PR DESCRIPTION
It makes running the game require having ran the importer.

Differences from my [previous pull request](https://github.com/zinnschlag/openmw/pull/548):
- Engine::setArchives(vector<string>& archives) changed to Engine::addArchive(const string& archive): the former forced to provide a definitive list of archives to load, the latter allows to add archives in several times
- no more default BSA archive loaded

A problem however: the search for the archive is case sensitive.
