### PR TITLE
fix eraseStatic()

### DIFF
--- a/apps/openmw/mwworld/store.hpp
+++ b/apps/openmw/mwworld/store.hpp
@@ -192,11 +192,14 @@ namespace MWWorld
             if (it != mStatic.end() && Misc::StringUtils::ciEqual(it->second.mId, id)) {
                 // delete from the static part of mShared
                 typename std::vector<T *>::iterator sharedIter = mShared.begin();
-                for (; sharedIter != (mShared.begin()+mStatic.size()); ++sharedIter) {
+                typename std::vector<T *>::iterator end = sharedIter + mStatic.size();
+
+                while (sharedIter != mShared.end() && sharedIter != end) { 
                     if((*sharedIter)->mId == item.mId) {
                         mShared.erase(sharedIter);
                         break;
                     }
+                    ++sharedIter;
                 }
                 mStatic.erase(it);
             }


### PR DESCRIPTION
Maybe it should not be used for deleting records before and after ESMStore setup simultaneously to simplify.
