### PR TITLE
Fallback changes, most of moons fallbacks.

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -46,6 +46,7 @@ namespace MWRender
 
 namespace MWWorld
 {
+    class Fallback;
     class CellStore;
     class Player;
     class LocalScripts;
@@ -103,7 +104,7 @@ namespace MWBase
 
             virtual void getTriangleBatchCount(unsigned int &triangles, unsigned int &batches) = 0;
 
-            virtual std::string getFallback (const std::string& key) const = 0;
+            virtual MWWorld::Fallback *getFallback () = 0;
 
             virtual MWWorld::Player& getPlayer() = 0;
 

--- a/apps/openmw/mwgui/charactercreation.cpp
+++ b/apps/openmw/mwgui/charactercreation.cpp
@@ -12,6 +12,7 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/soundmanager.hpp"
 #include "../mwbase/mechanicsmanager.hpp"
+#include "../mwworld/fallback.hpp"
 
 namespace
 {
@@ -23,14 +24,13 @@ namespace
     };
 
     const ESM::Class::Specialization mSpecializations[3]={ESM::Class::Combat, ESM::Class::Magic, ESM::Class::Stealth}; // The specialization for each answer
-
     Step sGenerateClassSteps(int number) {
-        MWBase::World *world = MWBase::Environment::get().getWorld();
         number++;
-        Step step = {world->getFallback("Question_"+boost::lexical_cast<std::string>(number)+"_Question"),
-        {world->getFallback("Question_"+boost::lexical_cast<std::string>(number)+"_AnswerOne"),
-        world->getFallback("Question_"+boost::lexical_cast<std::string>(number)+"_AnswerTwo"),
-        world->getFallback("Question_"+boost::lexical_cast<std::string>(number)+"_AnswerThree")},
+        MWWorld::Fallback* fallback=MWBase::Environment::get().getWorld()->getFallback();
+        Step step = {fallback->getFallbackString("Question_"+boost::lexical_cast<std::string>(number)+"_Question"),
+        {fallback->getFallbackString("Question_"+boost::lexical_cast<std::string>(number)+"_AnswerOne"),
+        fallback->getFallbackString("Question_"+boost::lexical_cast<std::string>(number)+"_AnswerTwo"),
+        fallback->getFallbackString("Question_"+boost::lexical_cast<std::string>(number)+"_AnswerThree")},
         "vo\\misc\\chargen qa"+boost::lexical_cast<std::string>(number)+".wav"
         };
         return step;

--- a/apps/openmw/mwgui/levelupdialog.cpp
+++ b/apps/openmw/mwgui/levelupdialog.cpp
@@ -9,6 +9,7 @@
 #include "../mwworld/player.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/esmstore.hpp"
+#include "../mwworld/fallback.hpp"
 
 #include "../mwmechanics/creaturestats.hpp"
 #include "../mwmechanics/npcstats.hpp"
@@ -138,9 +139,9 @@ namespace MWGui
 
         std::string levelupdescription;
         if(level>20)
-            levelupdescription=world->getFallback("Level_Up_Default");
+            levelupdescription=world->getFallback()->getFallbackString("Level_Up_Default");
         else
-            levelupdescription=world->getFallback("Level_Up_Level"+boost::lexical_cast<std::string>(level));
+            levelupdescription=world->getFallback()->getFallbackString("Level_Up_Level"+boost::lexical_cast<std::string>(level));
 
         mLevelDescription->setCaption (levelupdescription);
 

--- a/apps/openmw/mwrender/sky.cpp
+++ b/apps/openmw/mwrender/sky.cpp
@@ -21,6 +21,8 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 
+#include "../mwworld/fallback.hpp"
+
 #include "renderconst.hpp"
 #include "renderingmanager.hpp"
 
@@ -266,11 +268,12 @@ void SkyManager::create()
     mLightning->setVisible (false);
     mLightning->setDiffuseColour (ColourValue(3,3,3));
 
-    mSecunda = new Moon("secunda_texture", 0.5, Vector3(-0.4, 0.4, 0.5), mRootNode, "openmw_moon");
+    MWWorld::Fallback* fallback=MWBase::Environment::get().getWorld()->getFallback();
+    mSecunda = new Moon("secunda_texture", /*0.5*/fallback->getFallbackFloat("Moons_Secunda_Size")/100, Vector3(-0.4, 0.4, 0.5), mRootNode, "openmw_moon");
     mSecunda->setType(Moon::Type_Secunda);
     mSecunda->setRenderQueue(RQG_SkiesEarly+4);
 
-    mMasser = new Moon("masser_texture", 0.75, Vector3(-0.4, 0.4, 0.5), mRootNode, "openmw_moon");
+    mMasser = new Moon("masser_texture", /*0.75*/fallback->getFallbackFloat("Moons_Masser_Size")/100, Vector3(-0.4, 0.4, 0.5), mRootNode, "openmw_moon");
     mMasser->setRenderQueue(RQG_SkiesEarly+3);
     mMasser->setType(Moon::Type_Masser);
 
@@ -368,7 +371,7 @@ int SkyManager::getSecundaPhase() const
 void SkyManager::update(float duration)
 {
     if (!mEnabled) return;
-
+    MWWorld::Fallback* fallback=MWBase::Environment::get().getWorld()->getFallback();
     mCamera->getParentSceneNode ()->needUpdate ();
     mRootNode->setPosition(mCamera->getDerivedPosition());
 
@@ -381,7 +384,7 @@ void SkyManager::update(float duration)
     mMasser->setPhase( static_cast<Moon::Phase>( (int) ((mDay % 32)/4.f)) );
     mSecunda->setPhase ( static_cast<Moon::Phase>( (int) ((mDay % 32)/4.f)) );
 
-    mSecunda->setColour ( mMoonRed ? ColourValue(1.0, 0.0784, 0.0784) : ColourValue(1,1,1,1));
+    mSecunda->setColour ( mMoonRed ? fallback->getFallbackColour("Moons_Script_Color") : ColourValue(1,1,1,1));
     mMasser->setColour (ColourValue(1,1,1,1));
 
     if (mSunEnabled)

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -107,16 +107,14 @@ WeatherManager::WeatherManager(MWRender::RenderingManager* rendering,MWWorld::Fa
     blight.mAmbientLoopSoundID = "blight";
     setFallbackWeather(blight,"blight");
 
-    /*
     Weather snow;
     snow.mCloudTexture = "tx_bm_sky_snow.dds";
-    setFallbackWeather(snow, "snow")
+    setFallbackWeather(snow, "snow");
 
     Weather blizzard;
     blizzard.mCloudTexture = "tx_bm_sky_blizzard.dds";
     blizzard.mAmbientLoopSoundID = "BM Blizzard";
-    setFallbackWeather(blizzard,"blizzard")
-    */
+    setFallbackWeather(blizzard,"blizzard");
 }
 
 void WeatherManager::setWeather(const String& weather, bool instant)

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -415,13 +415,28 @@ void WeatherManager::update(float duration)
             mRendering->getSkyManager()->masserEnable();
             mRendering->getSkyManager()->secundaEnable();
 
-            float hour_fade;
-            if (mHour >= 7.f && mHour <= 14.f)
-                hour_fade = 1-(mHour-7)/3.f;
-            else if (mHour >= 14 && mHour <= 15.f)
-                hour_fade = mHour-14;
+            float secunda_hour_fade;
+            float secunda_fadeout_start=mFallback->getFallbackFloat("Moons_Secunda_Fade_Out_Start");
+            float secunda_fadein_start=mFallback->getFallbackFloat("Moons_Secunda_Fade_In_Start");
+            float secunda_fadein_finish=mFallback->getFallbackFloat("Moons_Secunda_Fade_In_Finish");
+
+            if (mHour >= secunda_fadeout_start && mHour <= secunda_fadein_start)
+                secunda_hour_fade = 1-(mHour-secunda_fadeout_start)/3.f;
+            else if (mHour >= secunda_fadein_start && mHour <= secunda_fadein_finish)
+                secunda_hour_fade = mHour-secunda_fadein_start;
             else
-                hour_fade = 1;
+                secunda_hour_fade = 1;
+
+            float masser_hour_fade;
+            float masser_fadeout_start=mFallback->getFallbackFloat("Moons_Masser_Fade_Out_Start");
+            float masser_fadein_start=mFallback->getFallbackFloat("Moons_Masser_Fade_In_Start");
+            float masser_fadein_finish=mFallback->getFallbackFloat("Moons_Masser_Fade_In_Finish");
+            if (mHour >= masser_fadeout_start && mHour <= masser_fadein_start)
+                masser_hour_fade = 1-(mHour-masser_fadeout_start)/3.f;
+            else if (mHour >= masser_fadein_start && mHour <= masser_fadein_finish)
+                masser_hour_fade = mHour-masser_fadein_start;
+            else
+                masser_hour_fade = 1;
 
             float angle = moonHeight*90.f;
 
@@ -445,8 +460,8 @@ void WeatherManager::update(float duration)
             else
                 masser_angle_fade = 1.f;
 
-            masser_angle_fade *= hour_fade;
-            secunda_angle_fade *= hour_fade;
+            masser_angle_fade *= masser_hour_fade;
+            secunda_angle_fade *= secunda_hour_fade;
 
             mRendering->getSkyManager()->setMasserFade(masser_angle_fade);
             mRendering->getSkyManager()->setSecundaFade(secunda_angle_fade);

--- a/apps/openmw/mwworld/weather.cpp
+++ b/apps/openmw/mwworld/weather.cpp
@@ -110,60 +110,12 @@ WeatherManager::WeatherManager(MWRender::RenderingManager* rendering,MWWorld::Fa
     /*
     Weather snow;
     snow.mCloudTexture = "tx_bm_sky_snow.dds";
-    snow.mCloudsMaximumPercent = 1.0;
-    snow.mTransitionDelta = 0.014;
-    snow.mSkySunriseColor = clr(196, 91, 91);
-    snow.mSkyDayColor = clr(153, 158, 166);
-    snow.mSkySunsetColor = clr(96, 115, 134);
-    snow.mSkyNightColor = clr(31, 35, 39);
-    snow.mFogSunriseColor = clr(106, 91, 91);
-    snow.mFogDayColor = clr(153, 158, 166);
-    snow.mFogSunsetColor = clr(96, 115, 134);
-    snow.mFogNightColor = clr(31, 35, 39);
-    snow.mAmbientSunriseColor = clr(92, 84, 84);
-    snow.mAmbientDayColor = clr(93, 96, 105);
-    snow.mAmbientSunsetColor = clr(70, 79, 87);
-    snow.mAmbientNightColor = clr(49, 58, 68);
-    snow.mSunSunriseColor = clr(141, 109, 109);
-    snow.mSunDayColor = clr(163, 169, 183);
-    snow.mSunSunsetColor = clr(101, 121, 141);
-    snow.mSunNightColor = clr(55, 66, 77);
-    snow.mSunDiscSunsetColor = clr(128, 128, 128);
-    snow.mLandFogDayDepth = 1.0;
-    snow.mLandFogNightDepth = 1.2;
-    snow.mWindSpeed = 0;
-    snow.mCloudSpeed = 1.5;
-    snow.mGlareView = 0;
-    mWeatherSettings["snow"] = snow;
+    setFallbackWeather(snow, "snow")
 
     Weather blizzard;
     blizzard.mCloudTexture = "tx_bm_sky_blizzard.dds";
-    blizzard.mCloudsMaximumPercent = 1.0;
-    blizzard.mTransitionDelta = 0.030;
-    blizzard.mSkySunriseColor = clr(91, 99, 106);
-    blizzard.mSkyDayColor = clr(121, 133, 145);
-    blizzard.mSkySunsetColor = clr(108, 115, 121);
-    blizzard.mSkyNightColor = clr(27, 29, 31);
-    blizzard.mFogSunriseColor = clr(91, 99, 106);
-    blizzard.mFogDayColor = clr(121, 133, 145);
-    blizzard.mFogSunsetColor = clr(108, 115, 121);
-    blizzard.mFogNightColor = clr(21, 24, 28);
-    blizzard.mAmbientSunriseColor = clr(84, 88, 92);
-    blizzard.mAmbientDayColor = clr(93, 96, 105);
-    blizzard.mAmbientSunsetColor = clr(83, 77, 75);
-    blizzard.mAmbientNightColor = clr(53, 62, 70);
-    blizzard.mSunSunriseColor = clr(114, 128, 146);
-    blizzard.mSunDayColor = clr(163, 169, 183);
-    blizzard.mSunSunsetColor = clr(106, 114, 136);
-    blizzard.mSunNightColor = clr(57, 66, 74);
-    blizzard.mSunDiscSunsetColor = clr(128, 128, 128);
-    blizzard.mLandFogDayDepth = 2.8;
-    blizzard.mLandFogNightDepth = 3.0;
-    blizzard.mWindSpeed = 0.9;
-    blizzard.mCloudSpeed = 7.5;
-    blizzard.mGlareView = 0;
     blizzard.mAmbientLoopSoundID = "BM Blizzard";
-    mWeatherSettings["blizzard"] = blizzard;
+    setFallbackWeather(blizzard,"blizzard")
     */
 }
 
@@ -471,20 +423,24 @@ void WeatherManager::update(float duration)
             else
                 hour_fade = 1;
 
-            float secunda_angle_fade;
-            float masser_angle_fade;
             float angle = moonHeight*90.f;
 
-            if (angle >= 30 && angle <= 50)
-                secunda_angle_fade = (angle-30)/20.f;
-            else if (angle <30)
+            float secunda_angle_fade;
+            float secunda_end_angle=mFallback->getFallbackFloat("Moons_Secunda_Fade_End_Angle");
+            float secunda_start_angle=mFallback->getFallbackFloat("Moons_Secunda_Fade_Start_Angle");
+            if (angle >= secunda_end_angle && angle <= secunda_start_angle)
+                secunda_angle_fade = (angle-secunda_end_angle)/20.f;
+            else if (angle < secunda_end_angle)
                 secunda_angle_fade = 0.f;
             else
                 secunda_angle_fade = 1.f;
 
-            if (angle >= 40 && angle <= 50)
-                masser_angle_fade = (angle-40)/10.f;
-            else if (angle <40)
+            float masser_angle_fade;
+            float masser_end_angle=mFallback->getFallbackFloat("Moons_Masser_Fade_End_Angle");
+            float masser_start_angle=mFallback->getFallbackFloat("Moons_Masser_Fade_Start_Angle");
+            if (angle >= masser_end_angle && angle <= masser_start_angle)
+                masser_angle_fade = (angle-masser_end_angle)/10.f;
+            else if (angle < masser_end_angle)
                 masser_angle_fade = 0.f;
             else
                 masser_angle_fade = 1.f;

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -154,11 +154,6 @@ namespace MWWorld
             mRendering->skyDisable();
     }
 
-    std::string World::getFallback (const std::string& key) const
-    {
-        return mFallback.getFallbackString(key);
-    }
-
     World::World (OEngine::Render::OgreRenderer& renderer,
         const Files::Collections& fileCollections,
         const std::vector<std::string>& master, const std::vector<std::string>& plugins,
@@ -265,6 +260,11 @@ namespace MWWorld
         }
 
         return 0;
+    }
+
+    MWWorld::Fallback *World::getFallback ()
+    {
+        return &mFallback;
     }
 
     Ptr::CellStore *World::getExterior (int x, int y)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -133,7 +133,7 @@ namespace MWWorld
 
             virtual void getTriangleBatchCount(unsigned int &triangles, unsigned int &batches);
 
-            virtual std::string getFallback (const std::string& key) const;
+            virtual Fallback *getFallback ();
 
             virtual Player& getPlayer();
 


### PR DESCRIPTION
Here is a bit rewritten getfallback function, it now returns Fallback pointer.
Also, there are some moons fallbacks, but probably not all that could be used. The values are sometimes hard to import here.
At the end, I've unlocked bloodmoon weather, but it's currently unused, maybe I'll try to implement it later.

P.S. Size values in sky.cpp should rest commented, as I've done, because they're different than new moons sizes. I've tested new moons size, and it looks good, but it's good idea to have them somethere in case of problems.
