### PR TITLE
Ignore comparisons defined for some dialogue functions

### DIFF
--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -440,6 +440,30 @@ bool MWDialogue::Filter::getSelectStructBoolean (const SelectWrapper& select) co
 
             return Misc::StringUtils::lowerCase (mActor.getCell()->mCell->mName)!=select.getName();
 
+        case SelectWrapper::Function_NotLocal:
+        {
+            std::string scriptName = MWWorld::Class::get (mActor).getScript (mActor);
+
+            if (scriptName.empty())
+                // This actor has no attached script, so there is no local variable
+                return true;
+
+            const ESM::Script *script =
+                MWBase::Environment::get().getWorld()->getStore().get<ESM::Script>().find (scriptName);
+
+            std::string name = select.getName();
+
+            int i = 0;
+            for (; i < script->mVarNames.size(); ++i)
+                if (Misc::StringUtils::lowerCase(script->mVarNames[i]) == name)
+                    break;
+
+            if (i >= script->mVarNames.size())
+                return true; // script does not have a variable of this name
+
+            return false;
+        }
+
         case SelectWrapper::Function_SameGender:
 
             return (player.get<ESM::NPC>()->mBase->mFlags & ESM::NPC::Female)==

--- a/apps/openmw/mwdialogue/filter.cpp
+++ b/apps/openmw/mwdialogue/filter.cpp
@@ -136,8 +136,12 @@ bool MWDialogue::Filter::testDisposition (const ESM::DialInfo& info, bool invert
 
 bool MWDialogue::Filter::testSelectStruct (const SelectWrapper& select) const
 {
-    if (select.isNpcOnly() && mActor.getTypeName()!=typeid (ESM::NPC).name())
-        return select.isInverted();
+    if (select.isNpcOnly() && (mActor.getTypeName() != typeid (ESM::NPC).name()))
+        // If the actor is a creature, we do not test the conditions applicable
+        // only to NPCs. Such conditions can never be satisfied, apart
+        // inverted ones (NotClass, NotRace, NotFaction return true
+        // because creatures are not of any race, class or faction).
+        return select.getType() == SelectWrapper::Type_Inverted;
 
     switch (select.getType())
     {
@@ -145,6 +149,9 @@ bool MWDialogue::Filter::testSelectStruct (const SelectWrapper& select) const
         case SelectWrapper::Type_Integer: return select.selectCompare (getSelectStructInteger (select));
         case SelectWrapper::Type_Numeric: return testSelectStructNumeric (select);
         case SelectWrapper::Type_Boolean: return select.selectCompare (getSelectStructBoolean (select));
+
+        // We must not do the comparison for inverted functions (eg. Function_NotClass)
+        case SelectWrapper::Type_Inverted: return getSelectStructBoolean (select);
     }
 
     return true;

--- a/apps/openmw/mwdialogue/selectwrapper.cpp
+++ b/apps/openmw/mwdialogue/selectwrapper.cpp
@@ -219,7 +219,6 @@ MWDialogue::SelectWrapper::Type MWDialogue::SelectWrapper::getType() const
     static const Function booleanFunctions[] =
     {
         Function_False,
-        Function_NotId, Function_NotFaction, Function_NotClass, Function_NotRace, Function_NotCell,
         Function_SameGender, Function_SameRace, Function_SameFaction,
         Function_PcCommonDisease, Function_PcBlightDisease, Function_PcCorprus,
         Function_PcExpelled,
@@ -228,6 +227,13 @@ MWDialogue::SelectWrapper::Type MWDialogue::SelectWrapper::getType() const
         Function_Attacked, Function_ShouldAttack,
         Function_CreatureTargetted,
         Function_PCWerewolf,
+        Function_None // end marker
+    };
+
+    static const Function invertedBooleanFunctions[] =
+    {
+        Function_NotId, Function_NotFaction, Function_NotClass,
+        Function_NotRace, Function_NotCell,
         Function_None // end marker
     };
 
@@ -245,14 +251,11 @@ MWDialogue::SelectWrapper::Type MWDialogue::SelectWrapper::getType() const
         if (booleanFunctions[i]==function)
             return Type_Boolean;
 
+    for (int i=0; invertedBooleanFunctions[i]!=Function_None; ++i)
+        if (invertedBooleanFunctions[i]==function)
+            return Type_Inverted;
+
     return Type_None;
-}
-
-bool MWDialogue::SelectWrapper::isInverted() const
-{
-    char type = mSelect.mSelectRule[1];
-
-    return type=='7' || type=='8' || type=='9' || type=='A' || type=='B' || type=='C';
 }
 
 bool MWDialogue::SelectWrapper::isNpcOnly() const
@@ -283,17 +286,17 @@ bool MWDialogue::SelectWrapper::isNpcOnly() const
 
 bool MWDialogue::SelectWrapper::selectCompare (int value) const
 {
-    return selectCompareImp (mSelect, value)!=isInverted(); // logic XOR
+    return selectCompareImp (mSelect, value);
 }
 
 bool MWDialogue::SelectWrapper::selectCompare (float value) const
 {
-    return selectCompareImp (mSelect, value)!=isInverted(); // logic XOR
+    return selectCompareImp (mSelect, value);
 }
 
 bool MWDialogue::SelectWrapper::selectCompare (bool value) const
 {
-    return selectCompareImp (mSelect, static_cast<int> (value))!=isInverted(); // logic XOR
+    return selectCompareImp (mSelect, static_cast<int> (value));
 }
 
 std::string MWDialogue::SelectWrapper::getName() const

--- a/apps/openmw/mwdialogue/selectwrapper.cpp
+++ b/apps/openmw/mwdialogue/selectwrapper.cpp
@@ -117,7 +117,7 @@ MWDialogue::SelectWrapper::Function MWDialogue::SelectWrapper::getFunction() con
         case '9': return Function_NotClass;
         case 'A': return Function_NotRace;
         case 'B': return Function_NotCell;
-        case 'C': return Function_Local;
+        case 'C': return Function_NotLocal;
     }
 
     return Function_None;
@@ -233,7 +233,7 @@ MWDialogue::SelectWrapper::Type MWDialogue::SelectWrapper::getType() const
     static const Function invertedBooleanFunctions[] =
     {
         Function_NotId, Function_NotFaction, Function_NotClass,
-        Function_NotRace, Function_NotCell,
+        Function_NotRace, Function_NotCell, Function_NotLocal,
         Function_None // end marker
     };
 

--- a/apps/openmw/mwdialogue/selectwrapper.cpp
+++ b/apps/openmw/mwdialogue/selectwrapper.cpp
@@ -262,7 +262,7 @@ bool MWDialogue::SelectWrapper::isNpcOnly() const
 {
     static const Function functions[] =
     {
-        Function_NotFaction, SelectWrapper::Function_NotClass, SelectWrapper::Function_NotRace,
+        Function_NotFaction, Function_NotClass, Function_NotRace,
         Function_SameGender, Function_SameRace, Function_SameFaction,
         Function_PcSkill,
         Function_PcExpelled,

--- a/apps/openmw/mwdialogue/selectwrapper.hpp
+++ b/apps/openmw/mwdialogue/selectwrapper.hpp
@@ -50,7 +50,8 @@ namespace MWDialogue
                 Type_None,
                 Type_Integer,
                 Type_Numeric,
-                Type_Boolean
+                Type_Boolean,
+                Type_Inverted
             };
 
         private:
@@ -66,8 +67,6 @@ namespace MWDialogue
             int getArgument() const;
 
             Type getType() const;
-
-            bool isInverted() const;
 
             bool isNpcOnly() const;
             ///< \attention Do not call any of the select functions for this select struct!

--- a/apps/openmw/mwdialogue/selectwrapper.hpp
+++ b/apps/openmw/mwdialogue/selectwrapper.hpp
@@ -22,6 +22,7 @@ namespace MWDialogue
                 Function_NotClass,
                 Function_NotRace,
                 Function_NotCell,
+                Function_NotLocal,
                 Function_Local,
                 Function_Global,
                 Function_SameGender, Function_SameRace, Function_SameFaction,

--- a/apps/openmw/mwworld/class.cpp
+++ b/apps/openmw/mwworld/class.cpp
@@ -169,7 +169,7 @@ namespace MWWorld
 
     bool Class::hasDetected (const MWWorld::Ptr& ptr, const MWWorld::Ptr& ptr2) const
     {
-        return false;
+        return true;
     }
 
     float Class::getArmorRating (const MWWorld::Ptr& ptr) const


### PR DESCRIPTION
The comparisons are ignored for the functions NotCell, NotClass, NotFaction, NotRace and NotId, as in vanilla. For consistency, they are also ignored for the function NotLocal.

The value return by the place-holder implementation of MWWorld::Class::hasDetected() is changed from false to true, because almost all NPCs now return a greeting forcing to close the dialogue window otherwise. This was not the case before because all NPCs were considered having a NoLore variable, thus some responses were not available.
