### PR TITLE
Added workaround for OpenCS compilation problems due to bug in Qt MOC co...

### DIFF
--- a/apps/opencs/editor.hpp
+++ b/apps/opencs/editor.hpp
@@ -2,9 +2,9 @@
 #define CS_EDITOR_H
 
 #include <QObject>
-
+#ifndef Q_MOC_RUN
 #include <components/files/configurationmanager.hpp>
-
+#endif
 #include "model/doc/documentmanager.hpp"
 
 #include "view/doc/viewmanager.hpp"


### PR DESCRIPTION
Added workaround for OpenCS compilation problems due to bug in Qt MOC compiler.

For details please see:

https://forum.openmw.org/viewtopic.php?f=7&t=1451
https://bugreports.qt-project.org/browse/QTBUG-22829

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
