### PR TITLE
Workaround for launcher compilation problems due to bug in Qt MOC compiler

### DIFF
--- a/apps/launcher/maindialog.hpp
+++ b/apps/launcher/maindialog.hpp
@@ -2,9 +2,9 @@
 #define MAINDIALOG_H
 
 #include <QMainWindow>
-
+#ifndef Q_MOC_RUN
 #include <components/files/configurationmanager.hpp>
-
+#endif
 #include "settings/gamesettings.hpp"
 #include "settings/graphicssettings.hpp"
 #include "settings/launchersettings.hpp"


### PR DESCRIPTION
Workaround for launcher compilation problems due to bug in Qt MOC compiler.

For details please see:

https://forum.openmw.org/viewtopic.php?f=7&t=1451
https://bugreports.qt-project.org/browse/QTBUG-22829

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
