### PR TITLE
Better handle material texture layers

### DIFF
--- a/components/nifogre/ogrenifloader.cpp
+++ b/components/nifogre/ogrenifloader.cpp
@@ -627,7 +627,7 @@ static Ogre::String getMaterial(const Nif::NiTriShape *shape, const Ogre::String
                 continue;
             }
 
-            const Nif::NiSourceTexture *st = texprop->textures[0].texture.getPtr();
+            const Nif::NiSourceTexture *st = texprop->textures[i].texture.getPtr();
             if(st->external)
                 texName[i] = findTextureName(st->filename);
             else


### PR DESCRIPTION
Prevents a crash when a material's texture layer is marked as in use, but neglects to specify an actual texture. This can occur with the dn\dn_ghost.nif mesh from the Greater Dwemer Ruins mod.
