### PR TITLE
Add non-breaking space to font code range

### DIFF
--- a/files/mygui/openmw_font.xml
+++ b/files/mygui/openmw_font.xml
@@ -9,6 +9,7 @@
         <Property key="OffsetHeight" value="0"/>
         <Codes>
             <Code range="33 126"/>
+            <Code range="160"/> <!-- Non-breaking space -->
             <Code range="192 382"/> <!-- Central and Eastern European languages glyphs -->
             <Code range="1025 1105"/>
             <Code range="2026"/> <!-- Ellipsis -->


### PR DESCRIPTION
Necessary at least for French.
