### PR TITLE
Bugfix #744: No wait dialogue after starting a new game

### DIFF
--- a/apps/openmw/engine.cpp
+++ b/apps/openmw/engine.cpp
@@ -368,7 +368,7 @@ void OMW::Engine::prepareEngine (Settings::Manager & settings)
     mEnvironment.setWorld( new MWWorld::World (*mOgre, mFileCollections, mMaster, mPlugins,
         mResDir, mCfgMgr.getCachePath(), mNewGame, mEncoder, mFallbackMap,
         mActivationDistanceOverride));
-    MWBase::Environment::get().getWorld()->setupPlayer(mNewGame);
+    MWBase::Environment::get().getWorld()->setupPlayer();
 
     //Load translation data
     mTranslationDataStorage.setEncoder(mEncoder);

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -323,7 +323,7 @@ namespace MWBase
             virtual void changeVanityModeScale(float factor) = 0;
             virtual bool vanityRotateCamera(float * rot) = 0;
 
-            virtual void setupPlayer(bool newGame) = 0;
+            virtual void setupPlayer() = 0;
             virtual void renderPlayer() = 0;
 
             virtual void activateDoor(const MWWorld::Ptr& door) = 0;

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -1110,6 +1110,13 @@ namespace MWGui
     {
         mLoadingScreen->loadingDone ();
     }
+    bool WindowManager::getRestEnabled()
+    {
+        //Enable rest dialogue if character creation finished
+        if(mRestAllowed==false && MWBase::Environment::get().getWorld()->getGlobalVariable ("chargenstate").mFloat==-1)
+            mRestAllowed=true;
+        return mRestAllowed;
+    }
 
     bool WindowManager::getPlayerSleeping ()
     {

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -220,7 +220,7 @@ namespace MWGui
     virtual void loadingDone();
 
     virtual void enableRest() { mRestAllowed = true; }
-    virtual bool getRestEnabled() { return mRestAllowed; }
+    virtual bool getRestEnabled();
 
     virtual bool getPlayerSleeping();
     virtual void wakeUpPlayer();

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -163,7 +163,8 @@ namespace MWWorld
         ToUTF8::Utf8Encoder* encoder, const std::map<std::string,std::string>& fallbackMap, int mActivationDistanceOverride)
     : mPlayer (0), mLocalScripts (mStore), mGlobalVariables (0),
       mSky (true), mCells (mStore, mEsm),
-      mNumFacing(0), mActivationDistanceOverride (mActivationDistanceOverride),mFallback(fallbackMap)
+      mNumFacing(0), mActivationDistanceOverride (mActivationDistanceOverride),
+      mFallback(fallbackMap), mNewGame(newGame)
     {
         mPhysics = new PhysicsSystem(renderer);
         mPhysEngine = mPhysics->getEngine();
@@ -214,7 +215,7 @@ namespace MWWorld
         // global variables
         mGlobalVariables = new Globals (mStore);
 
-        if (newGame)
+        if (mNewGame)
         {
             // set new game mark
             mGlobalVariables->setInt ("chargenstate", 1);
@@ -1465,12 +1466,12 @@ namespace MWWorld
         return mRendering->vanityRotateCamera(rot);
     }
 
-    void World::setupPlayer(bool newGame)
+    void World::setupPlayer()
     {
         const ESM::NPC* player = mStore.get<ESM::NPC>().find ("player");
         mPlayer = new MWWorld::Player (player, *this);
         mRendering->attachCameraTo(mPlayer->getPlayer());
-        if (newGame)
+        if (mNewGame)
         {
             MWWorld::Class::get(mPlayer->getPlayer()).getContainerStore(mPlayer->getPlayer()).fill(player->mInventory, "", mStore);
             MWWorld::Class::get(mPlayer->getPlayer()).getInventoryStore(mPlayer->getPlayer()).autoEquip (mPlayer->getPlayer());
@@ -1481,6 +1482,8 @@ namespace MWWorld
     {
         mRendering->renderPlayer(mPlayer->getPlayer());
         mPhysics->addActor(mPlayer->getPlayer());
+        if (mNewGame)
+            toggleCollisionMode();
     }
 
     void World::setupExternalRendering (MWRender::ExternalRendering& rendering)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -85,6 +85,8 @@ namespace MWWorld
             float mFaced2Distance;
             int mNumFacing;
 
+            bool mNewGame;
+
             std::map<MWWorld::Ptr, int> mDoorStates;
             ///< only holds doors that are currently moving. 0 means closing, 1 opening
 
@@ -371,7 +373,7 @@ namespace MWWorld
 
             virtual bool vanityRotateCamera(float * rot);
 
-            virtual void setupPlayer(bool newGame);
+            virtual void setupPlayer();
             virtual void renderPlayer();
 
             virtual void activateDoor(const MWWorld::Ptr& door);


### PR DESCRIPTION
EDIT: Also added a fix that enables collision when new game is started.
