### PR TITLE
Fixes BookTextParser

### DIFF
--- a/apps/openmw/mwgui/bookwindow.cpp
+++ b/apps/openmw/mwgui/bookwindow.cpp
@@ -76,7 +76,7 @@ namespace MWGui
                 parent = mRightPage;
 
             MyGUI::Widget* pageWidget = parent->createWidgetReal<MyGUI::Widget>("", MyGUI::FloatCoord(0.0,0.0,1.0,1.0), MyGUI::Align::Default, "BookPage" + boost::lexical_cast<std::string>(i));
-            parser.parse(*it, pageWidget, mLeftPage->getSize().width);
+            parser.parsePage(*it, pageWidget, mLeftPage->getSize().width);
             mPages.push_back(pageWidget);
             ++i;
         }
@@ -156,6 +156,21 @@ namespace MWGui
                 (*it)->setVisible(false);
             }
             ++i;
+        }
+        
+        //If it is the last page, hide the button "Next Page"
+        if (   (mCurrentPage+1)*2 == mPages.size()
+            || (mCurrentPage+1)*2 == mPages.size() + 1)
+        {
+            mNextPageButton->setVisible(false);
+        } else {
+            mNextPageButton->setVisible(true);
+        }
+        //If it is the fist page, hide the button "Prev Page"
+        if (mCurrentPage == 0) {
+            mPrevPageButton->setVisible(false);
+        } else {
+            mPrevPageButton->setVisible(true);
         }
     }
 

--- a/apps/openmw/mwgui/formatting.hpp
+++ b/apps/openmw/mwgui/formatting.hpp
@@ -32,7 +32,16 @@ namespace MWGui
              * @param maximum width
              * @return size of the created widgets
              */
-            MyGUI::IntSize parse(std::string text, MyGUI::Widget* parent, const int width);
+            MyGUI::IntSize parsePage(std::string text, MyGUI::Widget* parent, const int width);
+            
+            /**
+             * Parse markup as MyGUI widgets
+             * @param markup to parse
+             * @param parent for the created widgets
+             * @param maximum width
+             * @return size of the created widgets
+             */
+            MyGUI::IntSize parseScroll(std::string text, MyGUI::Widget* parent, const int width);
 
             /**
              * Split the specified text into pieces that fit in the area specified by width and height parameters

--- a/apps/openmw/mwgui/scrollwindow.cpp
+++ b/apps/openmw/mwgui/scrollwindow.cpp
@@ -39,7 +39,7 @@ namespace MWGui
         MWWorld::LiveCellRef<ESM::Book> *ref = mScroll.get<ESM::Book>();
 
         BookTextParser parser;
-        MyGUI::IntSize size = parser.parse(ref->mBase->mText, mTextView, 390);
+        MyGUI::IntSize size = parser.parseScroll(ref->mBase->mText, mTextView, 390);
 
         if (size.height > mTextView->getSize().height)
             mTextView->setCanvasSize(MyGUI::IntSize(410, size.height));


### PR DESCRIPTION
Fixes Bug #734 'Book empty line problem'
Hides buttons 'Next' and 'Prev' at the last and at the first page
Tag DIV is parsed for now

![- 02 05 2013 - 08 16 28](https://f.cloud.github.com/assets/467709/452331/3d95ab60-b2df-11e2-9124-02f549154295.png)
![- 02 05 2013 - 08 16 46](https://f.cloud.github.com/assets/467709/452332/3dd0dc8a-b2df-11e2-9dfb-2de321f80f06.png)
![- 02 05 2013 - 08 17 04](https://f.cloud.github.com/assets/467709/452333/3dcebb8a-b2df-11e2-9b77-3eb887a88e70.png)
![- 02 05 2013 - 08 17 18](https://f.cloud.github.com/assets/467709/452334/3dcefbae-b2df-11e2-9103-0540565210a9.png)
