### PR TITLE
Initialize values

### DIFF
--- a/apps/openmw/mwgui/loadingscreen.cpp
+++ b/apps/openmw/mwgui/loadingscreen.cpp
@@ -22,6 +22,7 @@ namespace MWGui
         , mLastRenderTime(0.f)
         , mLastWallpaperChangeTime(0.f)
         , mFirstLoad(true)
+        , mTotalRefsLoading(0)
     {
         getWidget(mLoadingText, "LoadingText");
         getWidget(mProgressBar, "ProgressBar");

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -104,7 +104,14 @@ static void getStateInfo(CharacterState state, std::string *group)
 
 
 CharacterController::CharacterController(const MWWorld::Ptr &ptr, MWRender::Animation *anim, CharacterState state, bool loop)
-    : mPtr(ptr), mAnimation(anim), mCharState(state), mSkipAnim(false), mMovingAnim(false), mSecondsOfRunning(0), mSecondsOfSwimming(0)
+    : mPtr(ptr)
+    , mAnimation(anim)
+    , mCharState(state)
+    , mSkipAnim(false)
+    , mMovingAnim(false)
+    , mSecondsOfRunning(0)
+    , mSecondsOfSwimming(0)
+    , mLooping(false)
 {
     if(!mAnimation)
         return;

--- a/apps/openmw/mwrender/water.hpp
+++ b/apps/openmw/mwrender/water.hpp
@@ -41,7 +41,9 @@ namespace MWRender {
     {
     public:
         Reflection(Ogre::SceneManager* sceneManager)
-            :   mSceneMgr(sceneManager) {}
+            : mSceneMgr(sceneManager)
+            , mIsUnderwater(false)
+            {}
         virtual ~Reflection() {}
 
         virtual void setHeight (float height) {}


### PR DESCRIPTION
This commit fixes some problems:

==8689== Conditional jump or move depends on uninitialised value(s)
==8689==    at 0x8C3F22C: MWGui::LoadingScreen::setLoadingProgress(std::string const&, int, int, int) (loadingscreen.cpp:86)
==8689==    by 0x8BA2207: MWGui::WindowManager::setLoadingProgress(std::string const&, int, int, int) (windowmanagerimp.cpp:1108)
==8689==    by 0x8D57B75: MWWorld::Scene::changeToInteriorCell(std::string const&, ESM::Position const&) (scene.cpp:399)
==8689==    by 0x8CCC929: MWWorld::World::changeToInteriorCell(std::string const&, ESM::Position const&) (worldimp.cpp:664)
==8689==    by 0x8DEAD91: OMW::Engine::prepareEngine(Settings::Manager&) (engine.cpp:428)
==8689==    by 0x8DEB4B3: OMW::Engine::go() (engine.cpp:464)
==8689==    by 0x8DDE985: main (main.cpp:274)
==8689== 

==8689== Conditional jump or move depends on uninitialised value(s)
==8689==    at 0x8DBD1D6: MWMechanics::CharacterController::forceStateUpdate() (character.cpp:313)
==8689==    by 0x8DC2132: MWMechanics::Actors::forceStateUpdate(MWWorld::Ptr const&) (actors.cpp:297)
==8689==    by 0x8DBB663: MWMechanics::MechanicsManager::forceStateUpdate(MWWorld::Ptr const&) (mechanicsmanagerimp.cpp:660)
==8689==    by 0x8B0F093: MWRender::NpcAnimation::setViewMode(MWRender::NpcAnimation::ViewMode) (npcanimation.cpp:154)
==8689==    by 0x8B05598: MWRender::Camera::toggleVanityMode(bool) (camera.cpp:135)
==8689==    by 0x8CD4EA6: MWRender::RenderingManager::toggleVanityMode(bool) (renderingmanager.hpp:72)
==8689==    by 0x8CD5017: MWWorld::World::toggleVanityMode(bool) (worldimp.hpp:361)
==8689==    by 0x8B55DE8: MWInput::InputManager::updateIdleTime(float) (inputmanagerimp.cpp:733)
==8689==    by 0x8B54356: MWInput::InputManager::update(float, bool) (inputmanagerimp.cpp:370)
==8689==    by 0x8DE88EB: OMW::Engine::frameRenderingQueued(Ogre::FrameEvent const&) (engine.cpp:81)
==8689==    by 0x43535A4: Ogre::Root::_fireFrameRenderingQueued(Ogre::FrameEvent&) (in /usr/lib/i386-linux-gnu/libOgreMain.so.1.8.1)
==8689==    by 0x4356001: Ogre::Root::_fireFrameRenderingQueued() (in /usr/lib/i386-linux-gnu/libOgreMain.so.1.8.1)
==8689== 

==9039== Conditional jump or move depends on uninitialised value(s)
==9039==    at 0x8B37888: MWRender::PlaneReflection::preRenderTargetUpdate(Ogre::RenderTargetEvent const&) (water.cpp:151)
==9039==    by 0x432E460: Ogre::RenderTarget::firePreUpdate() (in /usr/lib/i386-linux-gnu/libOgreMain.so.1.8.1)
==9039==    by 0xB8: ???
==9039== 
==9039== Conditional jump or move depends on uninitialised value(s)
==9039==    at 0x8B374BF: MWRender::PlaneReflection::renderQueueEnded(unsigned char, std::string const&, bool&) (water.cpp:123)
==9039==    by 0x435BF94: Ogre::SceneManager::fireRenderQueueEnded(unsigned char, std::string const&) (in /usr/lib/i386-linux-gnu/libOgreMain.so.1.8.1)
==9039==    by 0x435F5F1: Ogre::SceneManager::renderVisibleObjectsDefaultSequence() (in /usr/lib/i386-linux-gnu/libOgreMain.so.1.8.1)
==9039==    by 0x435DECC: Ogre::SceneManager::_renderVisibleObjects() (in /usr/lib/i386-linux-gnu/libOgreMain.so.1.8.1)
==9039==    by 0x436CE78: Ogre::SceneManager::_renderScene(Ogre::Camera_, Ogre::Viewport_, bool) (in /usr/lib/i386-linux-gnu/libOgreMain.so.1.8.1)
==9039==    by 0x419209C: Ogre::Camera::_renderScene(Ogre::Viewport*, bool) (in /usr/lib/i386-linux-gnu/libOgreMain.so.1.8.1)
