### PR TITLE
Fix warning issued by GCC 4.8 in oics/tinyxml.cpp

### DIFF
--- a/extern/oics/tinyxml.cpp
+++ b/extern/oics/tinyxml.cpp
@@ -706,9 +706,9 @@ void TiXmlElement::SetDoubleAttribute( const char * name, double val )
 {	
 	char buf[256];
 	#if defined(TIXML_SNPRINTF)		
-		TIXML_SNPRINTF( buf, sizeof(buf), "%f", val );
+               TIXML_SNPRINTF( buf, sizeof(buf), "%f", val );
 	#else
-		sprintf( buf, "%f", val );
+               sprintf( buf, "%f", val );
 	#endif
 	SetAttribute( name, buf );
 }
@@ -1266,9 +1266,9 @@ void TiXmlAttribute::SetDoubleValue( double _value )
 {
 	char buf [256];
 	#if defined(TIXML_SNPRINTF)		
-		TIXML_SNPRINTF( buf, sizeof(buf), "%lf", _value);
+               TIXML_SNPRINTF( buf, sizeof(buf), "%f", _value);
 	#else
-		sprintf (buf, "%lf", _value);
+               sprintf (buf, "%f", _value);
 	#endif
 	SetValue (buf);
 }


### PR DESCRIPTION
Fix warning issued by GCC 4.8 (and as far I remember 4.7 too)
about not supported "%lf" format string:

openmw/extern/oics/tinyxml.cpp: In member function ‘void TiXmlAttribute::SetDoubleValue(double)’:
openmw/extern/oics/tinyxml.cpp:1269:50: warning: ISO C++98 does not support the ‘%lf’ gnu_printf format [-Wformat=]
   TIXML_SNPRINTF( buf, sizeof(buf), "%lf", _value);
                                                  ^

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
