### PR TITLE
Fixed some CMake Bugs related to non-debian distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,7 +657,7 @@ if (NOT WIN32 AND NOT DPKG_PROGRAM AND NOT APPLE)
     # paths
     set(BINDIR "${CMAKE_INSTALL_PREFIX}/usr/bin" CACHE PATH "Where to install binaries")
     set(DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/usr/share" CACHE PATH "Sets the root of data directories to a non-default location")
-    set(DATADIR "${DATAROOTDIR}/openmw" CACHE PATH "Sets the openmw data directories to a non-default location")
+    set(DATADIR "${DATAROOTDIR}/games/openmw" CACHE PATH "Sets the openmw data directories to a non-default location")
     set(DOCDIR "${DATAROOTDIR}/doc/openmw" CACHE PATH "Sets the doc directory to a non-default location.")
     set(MANDIR "${DATAROOTDIR}/man" CACHE PATH "Where to install manpages")
     set(SYSCONFDIR "${CMAKE_INSTALL_PREFIX}/etc/openmw" CACHE PATH "Set config dir")
@@ -684,6 +684,10 @@ if (NOT WIN32 AND NOT DPKG_PROGRAM AND NOT APPLE)
     # Install icon and .desktop
     INSTALL(FILES "${OpenMW_SOURCE_DIR}/files/launcher/images/openmw.png" DESTINATION "${ICONDIR}")
     INSTALL(FILES "${OpenMW_BINARY_DIR}/openmw.desktop" DESTINATION "${DATAROOTDIR}/applications")
+    IF(BUILD_OPENCS)
+        INSTALL(FILES "${OpenMW_SOURCE_DIR}/files/opencs/opencs.png" DESTINATION "${ICONDIR}")
+        INSTALL(FILES "${OpenMW_BINARY_DIR}/opencs.desktop" DESTINATION "${DATAROOTDIR}/applications")
+    ENDIF(BUILD_OPENCS)
 
     # Install global configuration files
     INSTALL(FILES "${OpenMW_BINARY_DIR}/openmw.cfg.install" DESTINATION "${SYSCONFDIR}" RENAME "openmw.cfg" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,7 +656,7 @@ if (NOT WIN32 AND NOT DPKG_PROGRAM AND NOT APPLE)
     ## Non Debian based Linux building
     # paths
     set(BINDIR "${CMAKE_INSTALL_PREFIX}/usr/bin" CACHE PATH "Where to install binaries")
-    set(DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/share" CACHE PATH "Sets the root of data directories to a non-default location")
+    set(DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/usr/share" CACHE PATH "Sets the root of data directories to a non-default location")
     set(DATADIR "${DATAROOTDIR}/openmw" CACHE PATH "Sets the openmw data directories to a non-default location")
     set(DOCDIR "${DATAROOTDIR}/doc/openmw" CACHE PATH "Sets the doc directory to a non-default location.")
     set(MANDIR "${DATAROOTDIR}/man" CACHE PATH "Where to install manpages")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,12 +655,12 @@ endif (APPLE)
 if (NOT WIN32 AND NOT DPKG_PROGRAM AND NOT APPLE)
     ## Non Debian based Linux building
     # paths
-    set(BINDIR "${CMAKE_INSTALL_PREFIX}/usr/bin" CACHE PATH "Where to install binaries")
-    set(DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/usr/share" CACHE PATH "Sets the root of data directories to a non-default location")
+    set(BINDIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Where to install binaries")
+    set(DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/share" CACHE PATH "Sets the root of data directories to a non-default location")
     set(DATADIR "${DATAROOTDIR}/games/openmw" CACHE PATH "Sets the openmw data directories to a non-default location")
     set(DOCDIR "${DATAROOTDIR}/doc/openmw" CACHE PATH "Sets the doc directory to a non-default location.")
     set(MANDIR "${DATAROOTDIR}/man" CACHE PATH "Where to install manpages")
-    set(SYSCONFDIR "${CMAKE_INSTALL_PREFIX}/etc/openmw" CACHE PATH "Set config dir")
+    set(SYSCONFDIR "/etc/openmw" CACHE PATH "Set config dir")
     set(ICONDIR "${DATAROOTDIR}/pixmaps" CACHE PATH "Set icon dir")
 
     # Install binaries


### PR DESCRIPTION
This [greatly simplifies](https://github.com/bwrsandman/pkgbuild/commit/69b96667fe482032fa06860a61e9e1d4dbb2c466) the custom packaging needed in Arch Linux by allowing the use of `$ make install` which was broken prior to this.

I got rid of a bug that installed the application data (.desktop files) in `/share` instead of `/usr/share`.
I put openmw data files in `/usr/share/games/openmw`.

I don't think the change affects anyone who is not using `$ make install` on a non-debian machine.
