### PR TITLE
AddItem should only spawn a message box when called from dialogue

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -200,7 +200,7 @@ namespace MWBase
             virtual void removeDialog(OEngine::GUI::Layout* dialog) = 0;
             ///< Hides dialog and schedules dialog to be deleted.
 
-            virtual void messageBox (const std::string& message, const std::vector<std::string>& buttons = std::vector<std::string>()) = 0;
+            virtual void messageBox (const std::string& message, const std::vector<std::string>& buttons = std::vector<std::string>(), bool showInDialogueModeOnly = false) = 0;
             virtual void staticMessageBox(const std::string& message) = 0;
             virtual void removeStaticMessageBox() = 0;
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -584,18 +584,21 @@ namespace MWGui
         mGarbageDialogs.push_back(dialog);
     }
 
-    void WindowManager::messageBox (const std::string& message, const std::vector<std::string>& buttons)
+    void WindowManager::messageBox (const std::string& message, const std::vector<std::string>& buttons, bool showInDialogueModeOnly)
     {
-        if(buttons.empty()){
+        if (buttons.empty()) {
             /* If there are no buttons, and there is a dialogue window open, messagebox goes to the dialogue window */
-            if(!mGuiModes.empty() && mGuiModes.back() == GM_Dialogue)
+            if (getMode() == GM_Dialogue) {
                 mDialogueWindow->addMessageBox(MyGUI::LanguageManager::getInstance().replaceTags(message));
-            else
-                mMessageBoxManager->createMessageBox(message);
-        }
-
-        else
-        {
+            } else {
+                if (showInDialogueModeOnly) {
+                    if (getMode() == GM_Dialogue)
+                        mMessageBoxManager->createMessageBox(message);
+                } else {
+                    mMessageBoxManager->createMessageBox(message);
+                }
+            }
+        } else {
             mMessageBoxManager->createInteractiveMessageBox(message, buttons);
             MWBase::Environment::get().getInputManager()->changeInputMode(isGuiMode());
         }

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -191,7 +191,7 @@ namespace MWGui
 
     virtual void removeDialog(OEngine::GUI::Layout* dialog); ///< Hides dialog and schedules dialog to be deleted.
 
-    virtual void messageBox (const std::string& message, const std::vector<std::string>& buttons = std::vector<std::string>());
+    virtual void messageBox (const std::string& message, const std::vector<std::string>& buttons = std::vector<std::string>(), bool showInDialogueModeOnly = false);
     virtual void staticMessageBox(const std::string& message);
     virtual void removeStaticMessageBox();
     virtual void enterPressed ();

--- a/apps/openmw/mwscript/containerextensions.cpp
+++ b/apps/openmw/mwscript/containerextensions.cpp
@@ -66,8 +66,8 @@ namespace MWScript
 
                     MWWorld::Class::get (ptr).getContainerStore (ptr).add (ref.getPtr());
 
-                    // Spawn a messagebox (only for items added to player's inventory)
-                    if (ptr == MWBase::Environment::get().getWorld ()->getPlayer ().getPlayer())
+                    // Spawn a messagebox (only for items added to player's inventory and if player is talking to someone)
+                    if (ptr == MWBase::Environment::get().getWorld ()->getPlayer ().getPlayer() )
                     {
                         // The two GMST entries below expand to strings informing the player of what, and how many of it has been added to their inventory
                         std::string msgBox;
@@ -82,8 +82,8 @@ namespace MWScript
                             msgBox = MyGUI::LanguageManager::getInstance().replaceTags("#{sNotifyMessage61}");
                             msgBox = boost::str(boost::format(msgBox) % count % itemName);
                         }
-
-                        MWBase::Environment::get().getWindowManager()->messageBox(msgBox);
+                        std::vector <std::string> noButtons;
+                        MWBase::Environment::get().getWindowManager()->messageBox(msgBox, noButtons, /*showInDialogueModeOnly*/ true);
                     }
                 }
         };
@@ -161,12 +161,15 @@ namespace MWScript
                         }
                     }
                   
-                    // Spawn a messagebox (only for items added to player's inventory)
+                    // Spawn a messagebox (only for items removed from player's inventory)
                     if (ptr == MWBase::Environment::get().getWorld ()->getPlayer ().getPlayer())
                     {
                         // The two GMST entries below expand to strings informing the player of what, and how many of it has been removed from their inventory
                         std::string msgBox;
                         int numRemoved = (originalCount - count);
+                        if (numRemoved == 0)
+                            return;
+                        
                         if(numRemoved > 1)
                         {
                             msgBox = MyGUI::LanguageManager::getInstance().replaceTags("#{sNotifyMessage63}");
@@ -177,9 +180,8 @@ namespace MWScript
                             msgBox = MyGUI::LanguageManager::getInstance().replaceTags("#{sNotifyMessage62}");
                             msgBox = boost::str (boost::format(msgBox) % itemName);
                         }
-
-                        if (numRemoved > 0)
-                            MWBase::Environment::get().getWindowManager()->messageBox(msgBox);
+                        std::vector <std::string> noButtons;
+                        MWBase::Environment::get().getWindowManager()->messageBox(msgBox, noButtons, /*showInDialogueModeOnly*/ true);
                     }
                 }
         };


### PR DESCRIPTION
Fixes bug http://bugs.openmw.org/issues/751
- Changes the logic of WindowManager::messageBox()
- Fixes removeItem
- Fixes addItem
