### PR TITLE
AIWander Extra Idle Parameter

### DIFF
--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -181,7 +181,6 @@ namespace MWScript
                     runtime.pop();
 
                     std::vector<int> idleList;
-                    idleList.push_back (0); // why MW, why?
 
                     for (int i=2; i<10 && arg0; ++i)
                     {


### PR DESCRIPTION
An extra idle parameter was being passed into the idle parameters vector. (Thanks to Chris for pointing this out a few days ago)
