### PR TITLE
Bug 752 pt. 1

### DIFF
--- a/apps/openmw/mwgui/countdialog.cpp
+++ b/apps/openmw/mwgui/countdialog.cpp
@@ -18,8 +18,8 @@ namespace MWGui
         mOkButton->eventMouseButtonClick += MyGUI::newDelegate(this, &CountDialog::onOkButtonClicked);
         mItemEdit->eventEditTextChange += MyGUI::newDelegate(this, &CountDialog::onEditTextChange);
         mSlider->eventScrollChangePosition += MyGUI::newDelegate(this, &CountDialog::onSliderMoved);
-	// make sure we read the enter key being pressed to accept multiple items
-	mItemEdit->eventEditSelectAccept += MyGUI::newDelegate(this, &CountDialog::onEnterKeyPressed);
+		// make sure we read the enter key being pressed to accept multiple items
+		mItemEdit->eventEditSelectAccept += MyGUI::newDelegate(this, &CountDialog::onEnterKeyPressed);
     }
 
     void CountDialog::open(const std::string& item, const std::string& message, const int maxCount)
@@ -64,9 +64,7 @@ namespace MWGui
     {
         eventOkClicked(NULL, mSlider->getScrollPosition()+1);
 	
-	setVisible(false);
-	
-	eventDone(this);
+		setVisible(false);
     }
     
     void CountDialog::onEditTextChange(MyGUI::EditBox* _sender)

--- a/apps/openmw/mwgui/countdialog.cpp
+++ b/apps/openmw/mwgui/countdialog.cpp
@@ -18,6 +18,8 @@ namespace MWGui
         mOkButton->eventMouseButtonClick += MyGUI::newDelegate(this, &CountDialog::onOkButtonClicked);
         mItemEdit->eventEditTextChange += MyGUI::newDelegate(this, &CountDialog::onEditTextChange);
         mSlider->eventScrollChangePosition += MyGUI::newDelegate(this, &CountDialog::onSliderMoved);
+	// make sure we read the enter key being pressed to accept multiple items
+	mItemEdit->eventEditSelectAccept += MyGUI::newDelegate(this, &CountDialog::onEnterKeyPressed);
     }
 
     void CountDialog::open(const std::string& item, const std::string& message, const int maxCount)
@@ -37,6 +39,7 @@ namespace MWGui
                 width,
                 mMainWidget->getHeight());
 
+        // by default, the text edit field has the focus of the keyboard
         MyGUI::InputManager::getInstance().setKeyFocusWidget(mItemEdit);
 
         mSlider->setScrollPosition(maxCount-1);
@@ -54,7 +57,18 @@ namespace MWGui
 
         setVisible(false);
     }
-
+    
+    // essentially duplicating what the OK button does if user presses
+    // Enter key
+    void CountDialog::onEnterKeyPressed(MyGUI::EditBox* _sender)
+    {
+        eventOkClicked(NULL, mSlider->getScrollPosition()+1);
+	
+	setVisible(false);
+	
+	eventDone(this);
+    }
+    
     void CountDialog::onEditTextChange(MyGUI::EditBox* _sender)
     {
         if (_sender->getCaption() == "")

--- a/apps/openmw/mwgui/countdialog.hpp
+++ b/apps/openmw/mwgui/countdialog.hpp
@@ -25,11 +25,12 @@ namespace MWGui
             MyGUI::TextBox* mLabelText;
             MyGUI::Button* mOkButton;
             MyGUI::Button* mCancelButton;
-
+	    
             void onCancelButtonClicked(MyGUI::Widget* _sender);
             void onOkButtonClicked(MyGUI::Widget* _sender);
             void onEditTextChange(MyGUI::EditBox* _sender);
             void onSliderMoved(MyGUI::ScrollBar* _sender, size_t _position);
+	    void onEnterKeyPressed(MyGUI::EditBox* _sender);
     };
 
 }

--- a/apps/openmw/mwgui/countdialog.hpp
+++ b/apps/openmw/mwgui/countdialog.hpp
@@ -30,7 +30,7 @@ namespace MWGui
             void onOkButtonClicked(MyGUI::Widget* _sender);
             void onEditTextChange(MyGUI::EditBox* _sender);
             void onSliderMoved(MyGUI::ScrollBar* _sender, size_t _position);
-	    void onEnterKeyPressed(MyGUI::EditBox* _sender);
+			void onEnterKeyPressed(MyGUI::EditBox* _sender);
     };
 
 }


### PR DESCRIPTION
This allows the use of the Enter key to accept multiple items in the countdialog window.  The 'activate' key also can perform this function, but is not yet implemented yet.
