### PR TITLE
Fix build on gentoo linux with gcc 4.6

### DIFF
--- a/apps/openmw/mwgui/dialogue.cpp
+++ b/apps/openmw/mwgui/dialogue.cpp
@@ -1,5 +1,6 @@
 #include "dialogue.hpp"
 
+#include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include "../mwbase/environment.hpp"


### PR DESCRIPTION
Hi Zini

This patch fixes following error with gcc 4.6 on gentoo linux. Please pull, if you agree with the fix.

/var/tmp/portage/games-rpg/openmw-9999/work/openmw-9999/apps/openmw/mwgui/dialogue.cpp:
In constructor ‘MWGui::DialogueWindow::DialogueWindow()’:
/var/tmp/portage/games-rpg/openmw-9999/work/openmw-9999/apps/openmw/mwgui/dialogue.cpp:271:44:
error: ‘bind’ is not a member of ‘boost’

Thanks
edmondo
