### PR TITLE
Fix for missing dependency in usersettingsdialog.hpp

### DIFF
--- a/apps/opencs/settings/usersettingsdialog.hpp
+++ b/apps/opencs/settings/usersettingsdialog.hpp
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QStackedWidget>
+#include <QListWidgetItem>
 
 #include <components/files/configurationmanager.hpp>
 #include "usersettings.hpp"


### PR DESCRIPTION
Added missing #include. 
