### PR TITLE
AIWander - Repeat Parameter

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -1,8 +1,8 @@
 #include "aiwander.hpp"
 #include <iostream>
 
-MWMechanics::AiWander::AiWander(int distance, int duration, int timeOfDay, const std::vector<int>& idle):
-    mDistance(distance), mDuration(duration), mTimeOfDay(timeOfDay), mIdle(idle)
+MWMechanics::AiWander::AiWander(int distance, int duration, int timeOfDay, const std::vector<int>& idle, bool repeat):
+    mDistance(distance), mDuration(duration), mTimeOfDay(timeOfDay), mIdle(idle), mRepeat(repeat)
 {
 }
 

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -6,24 +6,24 @@
 
 namespace MWMechanics
 {
-
     class AiWander : public AiPackage
     {
-    public:
+        public:
 
-        AiWander(int distance, int duration, int timeOfDay, const std::vector<int>& idle);
-        virtual AiPackage *clone() const;
-        virtual bool execute (const MWWorld::Ptr& actor);
-        ///< \return Package completed?
-        virtual int getTypeId() const;
-        ///< 0: Wander
+            AiWander(int distance, int duration, int timeOfDay, const std::vector<int>& idle, bool repeat);
+            virtual AiPackage *clone() const;
+            virtual bool execute (const MWWorld::Ptr& actor);
+            ///< \return Package completed?
+            virtual int getTypeId() const;
+            ///< 0: Wander
 
-    private:
-        int mDistance;
-        int mDuration;
-        int mTimeOfDay;
-        std::vector<int> mIdle;
+        private:
+            int mDistance;
+            int mDuration;
+            int mTimeOfDay;
+            std::vector<int> mIdle;
+            bool mRepeat;
     };
-    }
+}
 
 #endif

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -181,11 +181,21 @@ namespace MWScript
                     runtime.pop();
 
                     std::vector<int> idleList;
+                    bool repeat = false;
 
-                    for (int i=2; i<10 && arg0; ++i)
+                    for(short i=1; i < 10 && arg0; ++i)
                     {
+                        if(!repeat)
+                            repeat = true;
                         Interpreter::Type_Integer idleValue = runtime[0].mInteger;
                         idleList.push_back(idleValue);
+                        runtime.pop();
+                        --arg0;
+                    }
+
+                    if(arg0)
+                    {
+                        repeat = runtime[0].mInteger;
                         runtime.pop();
                         --arg0;
                     }
@@ -193,7 +203,7 @@ namespace MWScript
                     // discard additional arguments (reset), because we have no idea what they mean.
                     for (unsigned int i=0; i<arg0; ++i) runtime.pop();
 
-                    MWMechanics::AiWander wanderPackage(range, duration, time, idleList);
+                    MWMechanics::AiWander wanderPackage(range, duration, time, idleList, repeat);
                     MWWorld::Class::get (ptr).getCreatureStats (ptr).getAiSequence().stack(wanderPackage);
                 }
         };


### PR DESCRIPTION
Added support for the AIWander Repeat parameter.

This parameter is set to 0 by default if only the three mandatory parameters are passed (range, duration, timeofday), it is set to 1 by default if 4 or more parameters are passed. If you set all 9 idle parameters you can also set the repeat parameter at the end to avoid using the default value.
