### PR TITLE
Console selection fix

### DIFF
--- a/apps/openmw/mwgui/console.cpp
+++ b/apps/openmw/mwgui/console.cpp
@@ -137,7 +137,7 @@ namespace MWGui
     void Console::disable()
     {
         setVisible(false);
-        setSelectedObject(MWWorld::Ptr());
+
         // Remove keyboard focus from the console input whenever the
         // console is turned off
         MyGUI::InputManager::getInstance().setKeyFocusWidget(NULL);

--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -1,8 +1,8 @@
 #include "aiwander.hpp"
 #include <iostream>
 
-MWMechanics::AiWander::AiWander(int distance, int duration, int timeOfDay, const std::vector<int>& idle):
-    mDistance(distance), mDuration(duration), mTimeOfDay(timeOfDay), mIdle(idle)
+MWMechanics::AiWander::AiWander(int distance, int duration, int timeOfDay, const std::vector<int>& idle, bool repeat):
+    mDistance(distance), mDuration(duration), mTimeOfDay(timeOfDay), mIdle(idle), mRepeat(repeat)
 {
 }
 

--- a/apps/openmw/mwmechanics/aiwander.hpp
+++ b/apps/openmw/mwmechanics/aiwander.hpp
@@ -6,24 +6,24 @@
 
 namespace MWMechanics
 {
-
     class AiWander : public AiPackage
     {
-    public:
+        public:
 
-        AiWander(int distance, int duration, int timeOfDay, const std::vector<int>& idle);
-        virtual AiPackage *clone() const;
-        virtual bool execute (const MWWorld::Ptr& actor);
-        ///< \return Package completed?
-        virtual int getTypeId() const;
-        ///< 0: Wander
+            AiWander(int distance, int duration, int timeOfDay, const std::vector<int>& idle, bool repeat);
+            virtual AiPackage *clone() const;
+            virtual bool execute (const MWWorld::Ptr& actor);
+            ///< \return Package completed?
+            virtual int getTypeId() const;
+            ///< 0: Wander
 
-    private:
-        int mDistance;
-        int mDuration;
-        int mTimeOfDay;
-        std::vector<int> mIdle;
+        private:
+            int mDistance;
+            int mDuration;
+            int mTimeOfDay;
+            std::vector<int> mIdle;
+            bool mRepeat;
     };
-    }
+}
 
 #endif

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -181,11 +181,21 @@ namespace MWScript
                     runtime.pop();
 
                     std::vector<int> idleList;
+                    bool repeat = false;
 
-                    for (int i=2; i<10 && arg0; ++i)
+                    for(short i=1; i < 10 && arg0; ++i)
                     {
+                        if(!repeat)
+                            repeat = true;
                         Interpreter::Type_Integer idleValue = runtime[0].mInteger;
                         idleList.push_back(idleValue);
+                        runtime.pop();
+                        --arg0;
+                    }
+
+                    if(arg0)
+                    {
+                        repeat = runtime[0].mInteger;
                         runtime.pop();
                         --arg0;
                     }
@@ -193,7 +203,7 @@ namespace MWScript
                     // discard additional arguments (reset), because we have no idea what they mean.
                     for (unsigned int i=0; i<arg0; ++i) runtime.pop();
 
-                    MWMechanics::AiWander wanderPackage(range, duration, time, idleList);
+                    MWMechanics::AiWander wanderPackage(range, duration, time, idleList, repeat);
                     MWWorld::Class::get (ptr).getCreatureStats (ptr).getAiSequence().stack(wanderPackage);
                 }
         };

--- a/apps/openmw/mwscript/aiextensions.cpp
+++ b/apps/openmw/mwscript/aiextensions.cpp
@@ -183,7 +183,7 @@ namespace MWScript
                     std::vector<int> idleList;
                     bool repeat = false;
 
-                    for(short i=1; i < 10 && arg0; ++i)
+                    for(int i=1; i < 10 && arg0; ++i)
                     {
                         if(!repeat)
                             repeat = true;
@@ -195,7 +195,7 @@ namespace MWScript
 
                     if(arg0)
                     {
-                        repeat = runtime[0].mInteger;
+                        repeat = runtime[0].mInteger != 0;
                         runtime.pop();
                         --arg0;
                     }


### PR DESCRIPTION
This is just a revision that allows the console to remember what you select between console sessions.  Before, when you would close the console, it would clear out the pointer of what object was selected.
