### PR TITLE
libcxx port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,12 @@ if (UNIX AND NOT APPLE)
     find_package (Threads)
 endif()
 
+include (CheckIncludeFileCXX)
+check_include_file_cxx(unordered_map HAVE_UNORDERED_MAP)
+if (HAVE_UNORDERED_MAP)
+    add_definitions(-DHAVE_UNORDERED_MAP)
+endif ()
+
 
 set(BOOST_COMPONENTS system filesystem program_options thread date_time wave)
 

--- a/apps/openmw/mwsound/ffmpeg_decoder.hpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.hpp
@@ -1,8 +1,6 @@
 #ifndef GAME_SOUND_FFMPEG_DECODER_H
 #define GAME_SOUND_FFMPEG_DECODER_H
 
-#include <string>
-
 // FIXME: This can't be right? The headers refuse to build without UINT64_C,
 // which only gets defined in stdint.h in either C99 mode or with this macro
 // defined...
@@ -13,6 +11,8 @@ extern "C"
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 }
+
+#include <string>
 
 #include "sound_decoder.hpp"
 

--- a/components/files/configurationmanager.hpp
+++ b/components/files/configurationmanager.hpp
@@ -3,6 +3,8 @@
 
 #ifdef _WIN32
 #include <boost/tr1/tr1/unordered_map>
+#elif defined HAVE_UNORDERED_MAP
+#include <unordered_map>
 #else
 #include <tr1/unordered_map>
 #endif
@@ -48,7 +50,11 @@ struct ConfigurationManager
         typedef Files::FixedPath<> FixedPathType;
 
         typedef const boost::filesystem::path& (FixedPathType::*path_type_f)() const;
-        typedef std::tr1::unordered_map<std::string, path_type_f> TokensMappingContainer;
+	#if defined HAVE_UNORDERED_MAP
+            typedef std::unordered_map<std::string, path_type_f> TokensMappingContainer;
+	#else
+            typedef std::tr1::unordered_map<std::string, path_type_f> TokensMappingContainer;
+	#endif
 
         void loadConfig(const boost::filesystem::path& path,
             boost::program_options::variables_map& variables,


### PR DESCRIPTION
Hi!
With these changes openmw builds and seems to run fine with clang/libc++ on current testing Gentoo.

I have not done extensive testing with other platforms (I don't have windows or macos available, and rebuilding dependencies for a different stdlib is a hassle), but the build seems to work with gcc-4.8.0. I do not expect to have broken anything, though.

Several approaches for selecting tr1/c++11 are possible, if this one isn't palatable just tell me and I can make one more to your liking. I couldn't find a way to directly check which stdlib is in use either in preprocessor (without messily including other headers) or in cmake, but I think this functionality test is more robust and future/c++11-proof.
