### PR TITLE
AIWander Minor Patch

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -126,7 +126,11 @@ bool MWMechanics::AiWander::execute (const MWWorld::Ptr& actor)
                 }
                 mCurrentNode = mAllowedNodes[index];
                 mAllowedNodes.erase(mAllowedNodes.begin() + index);
+                if(mAllowedNodes.empty())
+                    mDistance = 0;
             }
+            else
+                mDistance = 0;
         }
     }
 
@@ -203,7 +207,7 @@ bool MWMechanics::AiWander::execute (const MWWorld::Ptr& actor)
         }
     }
 
-    if(mMoveNow && mDistance && !mAllowedNodes.empty())
+    if(mMoveNow && mDistance)
     {
         if(!mPathFinder.isPathConstructed())
         {


### PR DESCRIPTION
Forgot an else statement and another check on an empty node vector, previously no nodes in range or only one would cause the AIWander to not do anything, now they will play idles correctly still.
