### PR TITLE
AIWander Segmentation Fault Fix

### DIFF
--- a/apps/openmw/mwmechanics/aiwander.cpp
+++ b/apps/openmw/mwmechanics/aiwander.cpp
@@ -38,6 +38,7 @@ MWMechanics::AiWander::AiWander(int distance, int duration, int timeOfDay, const
     srand(time(NULL));
     mStartTime = MWBase::Environment::get().getWorld()->getTimeStamp();
     mPlayedIdle = 0;
+    mPathgrid = NULL;
     mIdleChanceMultiplier =
         MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fIdleChanceMultiplier")->getFloat();
 
@@ -92,7 +93,9 @@ bool MWMechanics::AiWander::execute (const MWWorld::Ptr& actor)
         mCellX = actor.getCell()->mCell->mData.mX;
         mCellY = actor.getCell()->mCell->mData.mY;
 
-        if(mPathgrid->mPoints.empty())
+        if(!mPathgrid)
+            mDistance = 0;
+        else if(mPathgrid->mPoints.empty())
             mDistance = 0;
 
         if(mDistance)


### PR DESCRIPTION
Fixes the segmentation fault that used to occur when there was no pathgrid in the cell and a range was passed to AIWander.

Hopefully this will be the last post-merge patch of AIWander until it comes time to update the implementation. Sorry, I clearly did not thoroughly test AIWander before pushing, I won't make that mistake again.
