### PR TITLE
Added virtual destructors to classes LocalMapBase and EffectEditorBase.

### DIFF
--- a/apps/openmw/mwgui/mapwindow.cpp
+++ b/apps/openmw/mwgui/mapwindow.cpp
@@ -34,6 +34,10 @@ namespace MWGui
     {
     }
 
+    LocalMapBase::~LocalMapBase()
+    {
+    }
+
     void LocalMapBase::init(MyGUI::ScrollView* widget, MyGUI::ImageBox* compass, OEngine::GUI::Layout* layout, bool mapDragAndDrop)
     {
         mLocalMap = widget;

--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -14,6 +14,7 @@ namespace MWGui
     {
     public:
         LocalMapBase();
+        virtual ~LocalMapBase();
         void init(MyGUI::ScrollView* widget, MyGUI::ImageBox* compass, OEngine::GUI::Layout* layout, bool mapDragAndDrop=false);
 
         void setCellPrefix(const std::string& prefix);

--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -416,6 +416,10 @@ namespace MWGui
         mAddEffectDialog.setVisible (false);
     }
 
+    EffectEditorBase::~EffectEditorBase()
+    {
+    }
+
     void EffectEditorBase::startEditing ()
     {
         // get the list of magic effects that are known to the player

--- a/apps/openmw/mwgui/spellcreationdialog.hpp
+++ b/apps/openmw/mwgui/spellcreationdialog.hpp
@@ -84,7 +84,7 @@ namespace MWGui
     {
     public:
         EffectEditorBase();
-
+        virtual ~EffectEditorBase();
 
     protected:
         std::map<int, short> mButtonMapping; // maps button ID to effect ID


### PR DESCRIPTION
Got a warning when I compiled with /Wall in VS2010. The destructor of subclasses will never be executed and it may cause memoryleaks.
