### PR TITLE
Issue 812

### DIFF
--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -531,6 +531,17 @@ bool MainDialog::writeSettings()
         }
     }
 
+    if(!mGameSettings.hasMaster()) {
+            QMessageBox msgBox;
+            msgBox.setWindowTitle(tr("Error writing OpenMW configuration file"));
+            msgBox.setIcon(QMessageBox::Critical);
+            msgBox.setStandardButtons(QMessageBox::Ok);
+            msgBox.setText(tr("<br><b>You do not have any master files selected.</b><br><br> \
+                              Please select one and try again.<br>"));
+            msgBox.exec();
+            return false;
+    }
+
     // Game settings
     QFile file(userPath + QString("openmw.cfg"));
 

--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -608,8 +608,10 @@ void MainDialog::closeEvent(QCloseEvent *event)
 
 void MainDialog::play()
 {
-    if (!writeSettings())
+    if (!writeSettings()) {
         qApp->quit();
+        return;
+    }
 
     // Launch the game detached
     startProgram(QString("openmw"), true);

--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -531,17 +531,6 @@ bool MainDialog::writeSettings()
         }
     }
 
-    if(!mGameSettings.hasMaster()) {
-            QMessageBox msgBox;
-            msgBox.setWindowTitle(tr("Error writing OpenMW configuration file"));
-            msgBox.setIcon(QMessageBox::Critical);
-            msgBox.setStandardButtons(QMessageBox::Ok);
-            msgBox.setText(tr("<br><b>You do not have any master files selected.</b><br><br> \
-                              Please select one and try again.<br>"));
-            msgBox.exec();
-            return false;
-    }
-
     // Game settings
     QFile file(userPath + QString("openmw.cfg"));
 
@@ -622,6 +611,17 @@ void MainDialog::play()
     if (!writeSettings()) {
         qApp->quit();
         return;
+    }
+
+    if(!mGameSettings.hasMaster()) {
+            QMessageBox msgBox;
+            msgBox.setWindowTitle(tr("No master file selected"));
+            msgBox.setIcon(QMessageBox::Warning);
+            msgBox.setStandardButtons(QMessageBox::Ok);
+            msgBox.setText(tr("<br><b>You do not have any master files selected.</b><br><br> \
+                              OpenMW will not start without a master file selected.<br>"));
+            msgBox.exec();
+            return;
     }
 
     // Launch the game detached

--- a/apps/launcher/settings/gamesettings.hpp
+++ b/apps/launcher/settings/gamesettings.hpp
@@ -43,6 +43,7 @@ public:
     inline QStringList getDataDirs() { return mDataDirs; }
     inline void addDataDir(const QString &dir) { if(!dir.isEmpty()) mDataDirs.append(dir); }
     inline QString getDataLocal() {return mDataLocal; }
+    inline bool hasMaster() { return mSettings.count(QString("master")) > 0; }
 
     QStringList values(const QString &key, const QStringList &defaultValues = QStringList());
     bool readFile(QTextStream &stream);


### PR DESCRIPTION
There was a bug where the launcher would continue launching the game even if the settings write failed. I fixed that.
I also fixed the launcher continuing to launch despite there being no master files (OpenMW would then default to Morrowind.esm).
