### PR TITLE
libav-9 - add missing includes

### DIFF
--- a/apps/openmw/mwrender/videoplayer.cpp
+++ b/apps/openmw/mwrender/videoplayer.cpp
@@ -42,6 +42,14 @@ extern "C"
     #if AV_VERSION_INT(55, 0, 100) <= AV_VERSION_INT(LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO)
         #include <libavutil/time.h>
     #endif
+
+    // From libavcodec version 54.0.0 and onward the declaration of
+    // AV_CH_LAYOUT_* is removed from libavcodec/avcodec.h and moved to
+    // libavutil/channel_layout.h
+    #if AV_VERSION_INT(54, 0, 0) <= AV_VERSION_INT(LIBAVCODEC_VERSION_MAJOR, \
+        LIBAVCODEC_VERSION_MINOR, LIBAVCODEC_VERSION_MICRO)
+        #include <libavutil/channel_layout.h>
+    #endif
 }
 
 #define MAX_AUDIOQ_SIZE (5 * 16 * 1024)

--- a/apps/openmw/mwsound/ffmpeg_decoder.hpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.hpp
@@ -10,6 +10,14 @@ extern "C"
 {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
+
+// From libavcodec version 54.0.0 and onward the declaration of
+// AV_CH_LAYOUT_* is removed from libavcodec/avcodec.h and moved to
+// libavutil/channel_layout.h
+#if AV_VERSION_INT(54, 0, 0) <= AV_VERSION_INT(LIBAVCODEC_VERSION_MAJOR, \
+    LIBAVCODEC_VERSION_MINOR, LIBAVCODEC_VERSION_MICRO)
+    #include <libavutil/channel_layout.h>
+#endif
 }
 
 #include <string>


### PR DESCRIPTION
With these modifications, openmw builds (and runs) against libav-9.7 on Gentoo with Clang and libcxx.

I do not know if the checks are strictly necessary for backward compatibility, but there was precedent and I figure it can't hurt.
