### PR TITLE
Make OpenMW able to initialize SDL in windows builds

### DIFF
--- a/apps/openmw/CMakeLists.txt
+++ b/apps/openmw/CMakeLists.txt
@@ -112,6 +112,7 @@ target_link_libraries(openmw
     ${BULLET_LIBRARIES}
     ${MYGUI_LIBRARIES}
     ${SDL2_LIBRARY}
+    ${SDL2MAIN_LIBRARY}
     ${MYGUI_PLATFORM_LIBRARIES}
     ${SHINY_LIBRARIES}
     "oics"

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -2,6 +2,7 @@
 
 #include <components/files/configurationmanager.hpp>
 
+#include <SDL_main.h>
 #include "engine.hpp"
 
 #if defined(_WIN32) && !defined(_CONSOLE)


### PR DESCRIPTION
Otherwise this happens when trying to run the OpenMW build:

> ERROR: Could not initialize SDL! Application didn't initialize properly, did you include SDL_main.h in the file containing your main() function?
