### PR TITLE
Correction of libavutil version

### DIFF
--- a/apps/openmw/mwrender/videoplayer.cpp
+++ b/apps/openmw/mwrender/videoplayer.cpp
@@ -43,11 +43,11 @@ extern "C"
         #include <libavutil/time.h>
     #endif
 
-    // From libavcodec version 54.0.0 and onward the declaration of
+    // From libavutil version 52.2.0 and onward the declaration of
     // AV_CH_LAYOUT_* is removed from libavcodec/avcodec.h and moved to
     // libavutil/channel_layout.h
-    #if AV_VERSION_INT(54, 0, 0) <= AV_VERSION_INT(LIBAVCODEC_VERSION_MAJOR, \
-        LIBAVCODEC_VERSION_MINOR, LIBAVCODEC_VERSION_MICRO)
+    #if AV_VERSION_INT(52, 2, 0) <= AV_VERSION_INT(LIBAVUTIL_VERSION_MAJOR, \
+        LIBAVUTIL_VERSION_MINOR, LIBAVUTIL_VERSION_MICRO)
         #include <libavutil/channel_layout.h>
     #endif
 }

--- a/apps/openmw/mwsound/ffmpeg_decoder.hpp
+++ b/apps/openmw/mwsound/ffmpeg_decoder.hpp
@@ -11,11 +11,11 @@ extern "C"
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 
-// From libavcodec version 54.0.0 and onward the declaration of
+// From libavutil version 52.2.0 and onward the declaration of
 // AV_CH_LAYOUT_* is removed from libavcodec/avcodec.h and moved to
 // libavutil/channel_layout.h
-#if AV_VERSION_INT(54, 0, 0) <= AV_VERSION_INT(LIBAVCODEC_VERSION_MAJOR, \
-    LIBAVCODEC_VERSION_MINOR, LIBAVCODEC_VERSION_MICRO)
+#if AV_VERSION_INT(52, 2, 0) <= AV_VERSION_INT(LIBAVUTIL_VERSION_MAJOR, \
+    LIBAVUTIL_VERSION_MINOR, LIBAVUTIL_VERSION_MICRO)
     #include <libavutil/channel_layout.h>
 #endif
 }


### PR DESCRIPTION
52.2.0 is the version where headers were renamed.
