### PR TITLE
Bugfix #817: Dead NPCs and Creatures still have collision boxes

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -345,6 +345,8 @@ namespace MWBase
             virtual void getItemsOwnedBy (const MWWorld::Ptr& npc, std::vector<MWWorld::Ptr>& out) = 0;
             ///< get all items in active cells owned by this Npc
 
+            virtual void enableActorCollision(const MWWorld::Ptr& actor, bool enable) = 0;
+
             virtual void setupExternalRendering (MWRender::ExternalRendering& rendering) = 0;
 
             virtual int canRest() = 0;

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -462,6 +462,10 @@ void CharacterController::update(float duration, Movement &movement)
                 mAnimation->disable("torch");
         }
     }
+    else if (cls.getCreatureStats(mPtr).isDead())
+    {
+        MWBase::Environment::get().getWorld()->enableActorCollision(mPtr, false);
+    }
 
     if(mAnimation && !mSkipAnim)
     {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1751,4 +1751,18 @@ namespace MWWorld
                     out.push_back(searchPtrViaHandle(*it));
         }
     }
+
+    void World::enableActorCollision(const MWWorld::Ptr& actor, bool enable)
+    {
+        OEngine::Physic::PhysicActor *physicActor = mPhysEngine->getCharacter(actor.getRefData().getHandle());
+        
+        if (!enable)
+        {
+            physicActor->setScale(0.15);
+        }
+        else
+        {
+            physicActor->setScale(1);
+        }
+    }
 }

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1756,13 +1756,13 @@ namespace MWWorld
     {
         OEngine::Physic::PhysicActor *physicActor = mPhysEngine->getCharacter(actor.getRefData().getHandle());
         
-        if (!enable)
+        if (enable)
         {
-            physicActor->setScale(0.15);
+            physicActor->enableCollisionBody();
         }
         else
         {
-            physicActor->setScale(1);
+            physicActor->disableCollisionBody();
         }
     }
 }

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -394,6 +394,8 @@ namespace MWWorld
             virtual void getItemsOwnedBy (const MWWorld::Ptr& npc, std::vector<MWWorld::Ptr>& out);
             ///< get all items in active cells owned by this Npc
 
+            virtual void enableActorCollision(const MWWorld::Ptr& actor, bool enable);
+
             virtual void setupExternalRendering (MWRender::ExternalRendering& rendering);
 
             virtual int canRest();

--- a/libs/openengine/bullet/physic.cpp
+++ b/libs/openengine/bullet/physic.cpp
@@ -146,6 +146,16 @@ namespace Physic
         return collisionMode && onGround;
     }
 
+    void PhysicActor::disableCollisionBody()
+    {
+        mEngine->dynamicsWorld->removeRigidBody(mBody);
+    }
+    
+    void PhysicActor::enableCollisionBody()
+    {
+        mEngine->dynamicsWorld->addRigidBody(mBody);
+    }
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/libs/openengine/bullet/physic.hpp
+++ b/libs/openengine/bullet/physic.hpp
@@ -129,6 +129,9 @@ namespace Physic
 
         bool getOnGround() const;
 
+        void disableCollisionBody();
+        void enableCollisionBody();
+
 //HACK: in Visual Studio 2010 and presumably above, this structures alignment
 //		must be 16, but the built in operator new & delete don't properly
 //		perform this alignment.


### PR DESCRIPTION
I couldn't just get rid of the collision boxes since they're required for looting items. I couldn't rotate/reposition them, since that wouldn't work well with all creatures. 

I figured the most straightforward way to go about handling this would be to scale down the collision boxes. The main issue here is that you have a much smaller box to click on when you want to loot a corpse. It doesn't seem _too_ problematic, though (I tested it on mudcrabs)

If there is a better way, let me know and I'll fix it. I'm still not all too familiar with this codebase.
