### PR TITLE
Old sound stops playing when opening and closing door immediately.

### DIFF
--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -105,9 +105,19 @@ namespace MWBase
                                        PlayMode mode=Play_Normal) = 0;
             ///< Play a sound, independently of 3D-position
 
+            virtual SoundPtr playSound(const std::string& soundId, float volume, float pitch,
+                                        float offset, PlayMode mode=Play_Normal) = 0;
+            ///< Play a sound, independently of 3D-position
+            ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
+
             virtual SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
                                          float volume, float pitch, PlayMode mode=Play_Normal) = 0;
             ///< Play a sound from an object
+
+            virtual SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
+                                          float volume, float pitch, float offset, PlayMode mode=Play_Normal) = 0;
+            ///< Play a sound from an object
+            ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 
             virtual void stopSound3D(const MWWorld::Ptr &reference, const std::string& soundId) = 0;
             ///< Stop the given object from playing the given sound,

--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -102,20 +102,12 @@ namespace MWBase
             ///< Play a 2D audio track, using a custom decoder
 
             virtual SoundPtr playSound(const std::string& soundId, float volume, float pitch,
-                                       PlayMode mode=Play_Normal) = 0;
-            ///< Play a sound, independently of 3D-position
-
-            virtual SoundPtr playSound(const std::string& soundId, float volume, float pitch,
-                                        float offset, PlayMode mode=Play_Normal) = 0;
+                                        float offset=0, PlayMode mode=Play_Normal) = 0;
             ///< Play a sound, independently of 3D-position
             ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 
             virtual SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
-                                         float volume, float pitch, PlayMode mode=Play_Normal) = 0;
-            ///< Play a sound from an object
-
-            virtual SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
-                                          float volume, float pitch, float offset, PlayMode mode=Play_Normal) = 0;
+                                         float volume, float pitch, float offset=0, PlayMode mode=Play_Normal) = 0;
             ///< Play a sound from an object
             ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -6,6 +6,7 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
+#include "../mwbase/soundmanager.hpp"
 
 #include "../mwworld/player.hpp"
 #include "../mwworld/ptr.hpp"
@@ -142,10 +143,21 @@ namespace MWClass
                 // animated door
                 boost::shared_ptr<MWWorld::Action> action(new MWWorld::ActionDoor(ptr));
                 if (MWBase::Environment::get().getWorld()->getOpenOrCloseDoor(ptr))
+                {
+                    MWBase::Environment::get().getSoundManager()->stopSound3D (ptr,closeSound);
+                    float offset=ptr.getRefData().getLocalRotation().rot[2]/3.14159265*2.0;
+                    action->setSoundOffset(offset);
                     action->setSound(openSound);
+                }
                 else
+                {
+                    MWBase::Environment::get().getSoundManager()->stopSound3D (ptr,openSound);
+                    float offset=1.0-ptr.getRefData().getLocalRotation().rot[2]/3.14159265*2.0;
+                    //most if not all door have closing bang somewhere in the middle of the sound,
+                    //so we divide offset by two
+                    action->setSoundOffset(offset*0.5);
                     action->setSound(closeSound);
-
+                }
                 return action;
             }
         }

--- a/apps/openmw/mwsound/openal_output.cpp
+++ b/apps/openmw/mwsound/openal_output.cpp
@@ -491,6 +491,7 @@ public:
     virtual void stop();
     virtual bool isPlaying();
     virtual double getTimeOffset();
+    virtual double getLength();
     virtual void update();
 };
 
@@ -552,6 +553,17 @@ double OpenAL_Sound::getTimeOffset()
     throwALerror();
 
     return t;
+}
+
+double OpenAL_Sound::getLength()
+{
+    ALint bufferSize, frequency, channels, bitsPerSample;
+    alGetBufferi(mBuffer, AL_SIZE, &bufferSize);
+    alGetBufferi(mBuffer, AL_FREQUENCY, &frequency);
+    alGetBufferi(mBuffer, AL_CHANNELS, &channels);
+    alGetBufferi(mBuffer, AL_BITS, &bitsPerSample);
+
+    return (8.0*bufferSize)/(frequency*channels*bitsPerSample);
 }
 
 void OpenAL_Sound::updateAll(bool local)
@@ -818,7 +830,7 @@ void OpenAL_Output::bufferFinished(ALuint buf)
 }
 
 
-MWBase::SoundPtr OpenAL_Output::playSound(const std::string &fname, float vol, float basevol, float pitch, int flags)
+MWBase::SoundPtr OpenAL_Output::playSound(const std::string &fname, float vol, float basevol, float pitch, float offset,int flags)
 {
     boost::shared_ptr<OpenAL_Sound> sound;
     ALuint src=0, buf=0;
@@ -844,7 +856,13 @@ MWBase::SoundPtr OpenAL_Output::playSound(const std::string &fname, float vol, f
 
     sound->updateAll(true);
 
+    if (offset < 0)
+        offset = 0;
+    if (offset > 1)
+        offset=1;
+
     alSourcei(src, AL_BUFFER, buf);
+    alSourcef(src, AL_SEC_OFFSET, sound->getLength()*offset/pitch);
     alSourcePlay(src);
     throwALerror();
 
@@ -852,7 +870,7 @@ MWBase::SoundPtr OpenAL_Output::playSound(const std::string &fname, float vol, f
 }
 
 MWBase::SoundPtr OpenAL_Output::playSound3D(const std::string &fname, const Ogre::Vector3 &pos, float vol, float basevol, float pitch,
-                                            float min, float max, int flags)
+                                                float min, float max, float offset, int flags)
 {
     boost::shared_ptr<OpenAL_Sound> sound;
     ALuint src=0, buf=0;
@@ -878,7 +896,13 @@ MWBase::SoundPtr OpenAL_Output::playSound3D(const std::string &fname, const Ogre
 
     sound->updateAll(false);
 
+    if(offset<0)
+        offset=0;
+    if(offset>1)
+        offset=1;
+
     alSourcei(src, AL_BUFFER, buf);
+    alSourcef(src, AL_SEC_OFFSET, sound->getLength()*offset/pitch);
     alSourcePlay(src);
     throwALerror();
 

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -45,9 +45,11 @@ namespace MWSound
         virtual void init(const std::string &devname="");
         virtual void deinit();
 
-        virtual MWBase::SoundPtr playSound(const std::string &fname, float vol, float basevol, float pitch, int flags);
+        /// @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
+        virtual MWBase::SoundPtr playSound(const std::string &fname, float vol, float basevol, float pitch, float offset, int flags);
+        ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
         virtual MWBase::SoundPtr playSound3D(const std::string &fname, const Ogre::Vector3 &pos,
-                                             float vol, float basevol, float pitch, float min, float max, int flags);
+                                             float vol, float basevol, float pitch, float min, float max, float offset, int flags);
         virtual MWBase::SoundPtr streamSound(DecoderPtr decoder, float volume, float pitch, int flags);
 
         virtual void updateListener(const Ogre::Vector3 &pos, const Ogre::Vector3 &atdir, const Ogre::Vector3 &updir, Environment env);

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -24,9 +24,9 @@ namespace MWSound
         virtual void init(const std::string &devname="") = 0;
         virtual void deinit() = 0;
 
-        virtual MWBase::SoundPtr playSound(const std::string &fname, float vol, float basevol, float pitch, int flags) = 0;
+        virtual MWBase::SoundPtr playSound(const std::string &fname, float vol, float basevol, float pitch, float offset, int flags) = 0;
         virtual MWBase::SoundPtr playSound3D(const std::string &fname, const Ogre::Vector3 &pos,
-                                             float vol, float basevol, float pitch, float min, float max, int flags) = 0;
+                                             float vol, float basevol, float pitch, float min, float max, float offset, int flags) = 0;
         virtual MWBase::SoundPtr streamSound(DecoderPtr decoder, float volume, float pitch, int flags) = 0;
 
         virtual void updateListener(const Ogre::Vector3 &pos, const Ogre::Vector3 &atdir, const Ogre::Vector3 &updir, Environment env) = 0;

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -313,12 +313,6 @@ namespace MWSound
         return track;
     }
 
-
-    MWBase::SoundPtr SoundManager::playSound(const std::string& soundId, float volume, float pitch, PlayMode mode)
-    {
-        return playSound(soundId, volume, pitch, 0, mode);
-    }
-
     MWBase::SoundPtr SoundManager::playSound(const std::string& soundId,
             float volume, float pitch, float offset, PlayMode mode)
     {
@@ -340,12 +334,6 @@ namespace MWSound
             //std::cout <<"Sound Error: "<<e.what()<< std::endl;
         }
         return sound;
-    }
-
-    MWBase::SoundPtr SoundManager::playSound3D(const MWWorld::Ptr &ptr, const std::string& soundId,
-                                               float volume, float pitch, PlayMode mode)
-    {
-        return playSound3D(ptr, soundId, volume, pitch, 0, mode);
     }
 
     MWBase::SoundPtr SoundManager::playSound3D(const MWWorld::Ptr &ptr, const std::string& soundId,

--- a/apps/openmw/mwsound/soundmanagerimp.cpp
+++ b/apps/openmw/mwsound/soundmanagerimp.cpp
@@ -249,7 +249,7 @@ namespace MWSound
             const Ogre::Vector3 objpos(pos.pos[0], pos.pos[1], pos.pos[2]);
 
             MWBase::SoundPtr sound = mOutput->playSound3D(filePath, objpos, 1.0f, basevol, 1.0f,
-                                                          20.0f, 12750.0f, Play_Normal|Play_TypeVoice);
+                                                          20.0f, 12750.0f, 0, Play_Normal|Play_TypeVoice);
             mActiveSounds[sound] = std::make_pair(ptr, std::string("_say_sound"));
         }
         catch(std::exception &e)
@@ -267,7 +267,7 @@ namespace MWSound
             float basevol = volumeFromType(Play_TypeVoice);
             std::string filePath = "Sound/"+filename;
 
-            MWBase::SoundPtr sound = mOutput->playSound(filePath, 1.0f, basevol, 1.0f, Play_Normal|Play_TypeVoice);
+            MWBase::SoundPtr sound = mOutput->playSound(filePath, 1.0f, basevol, 1.0f,0, Play_Normal|Play_TypeVoice);
             mActiveSounds[sound] = std::make_pair(MWWorld::Ptr(), std::string("_say_sound"));
         }
         catch(std::exception &e)
@@ -316,6 +316,12 @@ namespace MWSound
 
     MWBase::SoundPtr SoundManager::playSound(const std::string& soundId, float volume, float pitch, PlayMode mode)
     {
+        return playSound(soundId, volume, pitch, 0, mode);
+    }
+
+    MWBase::SoundPtr SoundManager::playSound(const std::string& soundId,
+            float volume, float pitch, float offset, PlayMode mode)
+    {
         MWBase::SoundPtr sound;
         if(!mOutput->isInitialized())
             return sound;
@@ -325,7 +331,8 @@ namespace MWSound
             float min, max;
             std::string file = lookup(soundId, volume, min, max);
 
-            sound = mOutput->playSound(file, volume, basevol, pitch, mode|Play_TypeSfx);
+            sound = mOutput->playSound(file, volume, basevol, pitch, offset,
+                    mode | Play_TypeSfx);
             mActiveSounds[sound] = std::make_pair(MWWorld::Ptr(), soundId);
         }
         catch(std::exception &e)
@@ -337,6 +344,12 @@ namespace MWSound
 
     MWBase::SoundPtr SoundManager::playSound3D(const MWWorld::Ptr &ptr, const std::string& soundId,
                                                float volume, float pitch, PlayMode mode)
+    {
+        return playSound3D(ptr, soundId, volume, pitch, 0, mode);
+    }
+
+    MWBase::SoundPtr SoundManager::playSound3D(const MWWorld::Ptr &ptr, const std::string& soundId,
+                                                   float volume, float pitch, float offset, PlayMode mode)
     {
         MWBase::SoundPtr sound;
         if(!mOutput->isInitialized())
@@ -350,7 +363,7 @@ namespace MWSound
             const ESM::Position &pos = ptr.getRefData().getPosition();;
             const Ogre::Vector3 objpos(pos.pos[0], pos.pos[1], pos.pos[2]);
 
-            sound = mOutput->playSound3D(file, objpos, volume, basevol, pitch, min, max, mode|Play_TypeSfx);
+            sound = mOutput->playSound3D(file, objpos, volume, basevol, pitch, min, max, offset, mode|Play_TypeSfx);
             if((mode&Play_NoTrack))
                 mActiveSounds[sound] = std::make_pair(MWWorld::Ptr(), soundId);
             else

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -108,20 +108,13 @@ namespace MWSound
         virtual MWBase::SoundPtr playTrack(const DecoderPtr& decoder, PlayType type);
         ///< Play a 2D audio track, using a custom decoder
 
-        virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch, PlayMode mode=Play_Normal);
-        ///< Play a sound, independently of 3D-position
-
         virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch,
-                                                float offset, PlayMode mode=Play_Normal);
+                                                float offset=0, PlayMode mode=Play_Normal);
         ///< Play a sound, independently of 3D-position
         ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 
         virtual MWBase::SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
-                                             float volume, float pitch, PlayMode mode=Play_Normal);
-        ///< Play a sound from an object
-
-        virtual MWBase::SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
-                                      float volume, float pitch,float offset, PlayMode mode=Play_Normal);
+                                      float volume, float pitch,float offset=0, PlayMode mode=Play_Normal);
         ///< Play a sound from an object
         ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -111,9 +111,19 @@ namespace MWSound
         virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch, PlayMode mode=Play_Normal);
         ///< Play a sound, independently of 3D-position
 
+        virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch,
+                                                float offset, PlayMode mode=Play_Normal);
+        ///< Play a sound, independently of 3D-position
+        ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
+
         virtual MWBase::SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
                                              float volume, float pitch, PlayMode mode=Play_Normal);
         ///< Play a sound from an object
+
+        virtual MWBase::SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
+                                      float volume, float pitch,float offset, PlayMode mode=Play_Normal);
+        ///< Play a sound from an object
+        ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 
         virtual void stopSound3D(const MWWorld::Ptr &reference, const std::string& soundId);
         ///< Stop the given object from playing the given sound,

--- a/apps/openmw/mwworld/action.cpp
+++ b/apps/openmw/mwworld/action.cpp
@@ -11,7 +11,7 @@ const MWWorld::Ptr& MWWorld::Action::getTarget() const
     return mTarget;
 }
 
-MWWorld::Action::Action (bool keepSound, const Ptr& target) : mKeepSound (keepSound), mTarget (target)
+MWWorld::Action::Action (bool keepSound, const Ptr& target) : mKeepSound (keepSound), mTarget (target), mSoundOffset(0)
 {}
 
 MWWorld::Action::~Action() {}
@@ -23,15 +23,15 @@ void MWWorld::Action::execute (const Ptr& actor)
         if (mKeepSound && actor.getRefData().getHandle()=="player")
         {
             // sound moves with player when teleporting
-            MWBase::Environment::get().getSoundManager()->playSound(mSoundId, 1.0, 1.0,
+            MWBase::Environment::get().getSoundManager()->playSound(mSoundId, 1.0, 1.0, mSoundOffset,
                 MWBase::SoundManager::Play_NoTrack);
         }
         else
         {
             bool local = mTarget.isEmpty() || !mTarget.isInCell(); // no usable target
-        
+
             MWBase::Environment::get().getSoundManager()->playSound3D (local ? actor : mTarget,
-                mSoundId, 1.0, 1.0,
+                mSoundId, 1.0, 1.0, mSoundOffset,
                 mKeepSound ? MWBase::SoundManager::Play_NoTrack : MWBase::SoundManager::Play_Normal);
         }
     }
@@ -42,4 +42,9 @@ void MWWorld::Action::execute (const Ptr& actor)
 void MWWorld::Action::setSound (const std::string& id)
 {
     mSoundId = id;
+}
+
+void MWWorld::Action::setSoundOffset(float offset)
+{
+    mSoundOffset=offset;
 }

--- a/apps/openmw/mwworld/action.hpp
+++ b/apps/openmw/mwworld/action.hpp
@@ -11,6 +11,7 @@ namespace MWWorld
     class Action
     {
             std::string mSoundId;
+            float mSoundOffset;
             bool mKeepSound;
             Ptr mTarget;
 
@@ -34,6 +35,7 @@ namespace MWWorld
             void execute (const Ptr& actor);
 
             void setSound (const std::string& id);
+            void setSoundOffset(float offset);
     };
 }
 


### PR DESCRIPTION
Previously opening/closing sound didn't stop when player attempted to open/close the door again. Door sounds are now synchronized based on angle - the more open/closed the door are, the more player can hear.
That's an attempt to solve:
http://bugs.openmw.org/issues/796
