### PR TITLE
Minor fixes

### DIFF
--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -106,10 +106,10 @@ std::string ruleString(ESM::DialInfo::SelectStruct ss)
     {
     case '0': oper_str = "=="; break;
     case '1': oper_str = "!="; break;
-    case '2': oper_str = "< "; break;
-    case '3': oper_str = "<="; break;
-    case '4': oper_str = "> "; break;
-    case '5': oper_str = ">="; break;
+    case '2': oper_str = "> "; break;
+    case '3': oper_str = ">="; break;
+    case '4': oper_str = "< "; break;
+    case '5': oper_str = "<="; break;
     }
 
     std::ostringstream stream;

--- a/libs/openengine/ogre/renderer.cpp
+++ b/libs/openengine/ogre/renderer.cpp
@@ -293,7 +293,7 @@ void OgreRenderer::createWindow(const std::string &title, const WindowSettings& 
     struct SDL_SysWMinfo wmInfo;
     SDL_VERSION(&wmInfo.version);
 
-    if(-1 == SDL_GetWindowWMInfo(mSDLWindow, &wmInfo))
+    if(SDL_FALSE == SDL_GetWindowWMInfo(mSDLWindow, &wmInfo))
         throw std::runtime_error("Couldn't get WM Info!");
 
     Ogre::String winHandle;


### PR DESCRIPTION
The comparison operators reported by esmtool are swapped (while ingame they are not: [selectwrapper.cpp](https://github.com/PotatoesMaster/openmw/blob/fallback-defaults/apps/openmw/mwdialogue/selectwrapper.cpp#L20))
