### PR TITLE
Old door sound fades out on door open/close. Door sound is synchronised to angle.

### DIFF
--- a/apps/openmw/mwbase/soundmanager.hpp
+++ b/apps/openmw/mwbase/soundmanager.hpp
@@ -103,13 +103,16 @@ namespace MWBase
             ///< Play a 2D audio track, using a custom decoder
 
             virtual SoundPtr playSound(const std::string& soundId, float volume, float pitch,
-                                       PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal) = 0;
+                                       PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal,
+                                       float offset=0) = 0;
             ///< Play a sound, independently of 3D-position
+            ///< @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
 
             virtual SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
                                          float volume, float pitch, PlayType type=Play_TypeSfx,
-                                         PlayMode mode=Play_Normal) = 0;
+                                         PlayMode mode=Play_Normal, float offset=0) = 0;
             ///< Play a sound from an object
+            ///< @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
 
             virtual void stopSound3D(const MWWorld::Ptr &reference, const std::string& soundId) = 0;
             ///< Stop the given object from playing the given sound,
@@ -122,6 +125,12 @@ namespace MWBase
 
             virtual void stopSound(const std::string& soundId) = 0;
             ///< Stop a non-3d looping sound
+
+            virtual void fadeOutSound3D(const MWWorld::Ptr &reference, const std::string& soundId, float duration) = 0;
+            ///< Fade out given sound (that is already playing) of given object
+            ///< @param reference Reference to object, whose sound is faded out
+            ///< @param soundId ID of the sound to fade out.
+            ///< @param duration Time until volume reaches 0.
 
             virtual bool getSoundPlaying(const MWWorld::Ptr &reference, const std::string& soundId) const = 0;
             ///< Is the given sound currently playing on the given object?

--- a/apps/openmw/mwclass/door.cpp
+++ b/apps/openmw/mwclass/door.cpp
@@ -6,6 +6,7 @@
 #include "../mwbase/environment.hpp"
 #include "../mwbase/world.hpp"
 #include "../mwbase/windowmanager.hpp"
+#include "../mwbase/soundmanager.hpp"
 
 #include "../mwworld/player.hpp"
 #include "../mwworld/ptr.hpp"
@@ -142,9 +143,23 @@ namespace MWClass
                 // animated door
                 boost::shared_ptr<MWWorld::Action> action(new MWWorld::ActionDoor(ptr));
                 if (MWBase::Environment::get().getWorld()->getOpenOrCloseDoor(ptr))
+                {
+                    MWBase::Environment::get().getSoundManager()->fadeOutSound3D(ptr,
+                            closeSound, 0.5);
+                    float offset = ptr.getRefData().getLocalRotation().rot[2]/ 3.14159265 * 2.0;
+                    action->setSoundOffset(offset);
                     action->setSound(openSound);
+                }
                 else
+                {
+                    MWBase::Environment::get().getSoundManager()->fadeOutSound3D(ptr,
+                                                openSound, 0.5);
+                    float offset = 1.0 - ptr.getRefData().getLocalRotation().rot[2]/ 3.14159265 * 2.0;
+                    //most if not all door have closing bang somewhere in the middle of the sound,
+                    //so we divide offset by two
+                    action->setSoundOffset(offset * 0.5);
                     action->setSound(closeSound);
+                }
 
                 return action;
             }

--- a/apps/openmw/mwsound/openal_output.hpp
+++ b/apps/openmw/mwsound/openal_output.hpp
@@ -45,9 +45,11 @@ namespace MWSound
         virtual void init(const std::string &devname="");
         virtual void deinit();
 
-        virtual MWBase::SoundPtr playSound(const std::string &fname, float vol, float basevol, float pitch, int flags);
+        /// @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
+        virtual MWBase::SoundPtr playSound(const std::string &fname, float vol, float basevol, float pitch, int flags, float offset);
+        /// @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
         virtual MWBase::SoundPtr playSound3D(const std::string &fname, const Ogre::Vector3 &pos,
-                                             float vol, float basevol, float pitch, float min, float max, int flags);
+                                             float vol, float basevol, float pitch, float min, float max, int flags, float offset);
         virtual MWBase::SoundPtr streamSound(DecoderPtr decoder, float volume, float pitch, int flags);
 
         virtual void updateListener(const Ogre::Vector3 &pos, const Ogre::Vector3 &atdir, const Ogre::Vector3 &updir, Environment env);

--- a/apps/openmw/mwsound/sound.hpp
+++ b/apps/openmw/mwsound/sound.hpp
@@ -22,6 +22,7 @@ namespace MWSound
         float mMinDistance;
         float mMaxDistance;
         int mFlags;
+        float mFadeOutTime;
 
     public:
         virtual void stop() = 0;
@@ -29,7 +30,7 @@ namespace MWSound
         virtual double getTimeOffset() = 0;
         void setPosition(const Ogre::Vector3 &pos) { mPos = pos; }
         void setVolume(float volume) { mVolume = volume; }
-
+        void setFadeout(float duration) { mFadeOutTime=duration; }
         MWBase::SoundManager::PlayType getPlayType() const
         { return (MWBase::SoundManager::PlayType)(mFlags&MWBase::SoundManager::Play_TypeMask); }
 
@@ -42,6 +43,7 @@ namespace MWSound
           , mMinDistance(mindist)
           , mMaxDistance(maxdist)
           , mFlags(flags)
+          , mFadeOutTime(0)
         { }
         virtual ~Sound() { }
 

--- a/apps/openmw/mwsound/sound_output.hpp
+++ b/apps/openmw/mwsound/sound_output.hpp
@@ -24,9 +24,11 @@ namespace MWSound
         virtual void init(const std::string &devname="") = 0;
         virtual void deinit() = 0;
 
-        virtual MWBase::SoundPtr playSound(const std::string &fname, float vol, float basevol, float pitch, int flags) = 0;
+        /// @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
+        virtual MWBase::SoundPtr playSound(const std::string &fname, float vol, float basevol, float pitch, int flags, float offset) = 0;
+        /// @param offset Value from [0,1] meaning from which fraction the sound the playback starts.
         virtual MWBase::SoundPtr playSound3D(const std::string &fname, const Ogre::Vector3 &pos,
-                                             float vol, float basevol, float pitch, float min, float max, int flags) = 0;
+                                             float vol, float basevol, float pitch, float min, float max, int flags, float offset) = 0;
         virtual MWBase::SoundPtr streamSound(DecoderPtr decoder, float volume, float pitch, int flags) = 0;
 
         virtual void updateListener(const Ogre::Vector3 &pos, const Ogre::Vector3 &atdir, const Ogre::Vector3 &updir, Environment env) = 0;

--- a/apps/openmw/mwsound/soundmanagerimp.hpp
+++ b/apps/openmw/mwsound/soundmanagerimp.hpp
@@ -106,13 +106,15 @@ namespace MWSound
         virtual MWBase::SoundPtr playTrack(const DecoderPtr& decoder, PlayType type);
         ///< Play a 2D audio track, using a custom decoder
 
-        virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch, PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal);
+        virtual MWBase::SoundPtr playSound(const std::string& soundId, float volume, float pitch, PlayType type=Play_TypeSfx, PlayMode mode=Play_Normal, float offset=0);
         ///< Play a sound, independently of 3D-position
+        ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 
         virtual MWBase::SoundPtr playSound3D(const MWWorld::Ptr &reference, const std::string& soundId,
                                              float volume, float pitch, PlayType type=Play_TypeSfx,
-                                             PlayMode mode=Play_Normal);
+                                             PlayMode mode=Play_Normal, float offset=0);
         ///< Play a sound from an object
+        ///< @param offset value from [0,1], when to start playback. 0 is beginning, 1 is end.
 
         virtual void stopSound3D(const MWWorld::Ptr &reference, const std::string& soundId);
         ///< Stop the given object from playing the given sound,
@@ -125,6 +127,12 @@ namespace MWSound
 
         virtual void stopSound(const std::string& soundId);
         ///< Stop a non-3d looping sound
+
+        virtual void fadeOutSound3D(const MWWorld::Ptr &reference, const std::string& soundId, float duration);
+        ///< Fade out given sound (that is already playing) of given object
+        ///< @param reference Reference to object, whose sound is faded out
+        ///< @param soundId ID of the sound to fade out.
+        ///< @param duration Time until volume reaches 0.
 
         virtual bool getSoundPlaying(const MWWorld::Ptr &reference, const std::string& soundId) const;
         ///< Is the given sound currently playing on the given object?

--- a/apps/openmw/mwworld/action.cpp
+++ b/apps/openmw/mwworld/action.cpp
@@ -11,7 +11,7 @@ const MWWorld::Ptr& MWWorld::Action::getTarget() const
     return mTarget;
 }
 
-MWWorld::Action::Action (bool keepSound, const Ptr& target) : mKeepSound (keepSound), mTarget (target)
+MWWorld::Action::Action (bool keepSound, const Ptr& target) : mKeepSound (keepSound), mTarget (target), mSoundOffset(0)
 {}
 
 MWWorld::Action::~Action() {}
@@ -21,14 +21,16 @@ void MWWorld::Action::execute (const Ptr& actor)
     if (!mSoundId.empty())
     {
         if (mKeepSound && actor.getRefData().getHandle()=="player")
-            MWBase::Environment::get().getSoundManager()->playSound(mSoundId, 1.0, 1.0);
+            MWBase::Environment::get().getSoundManager()->playSound(mSoundId, 1.0, 1.0,
+                    MWBase::SoundManager::Play_TypeSfx, MWBase::SoundManager::Play_Normal,mSoundOffset);
         else
         {
             bool local = mTarget.isEmpty() || !mTarget.isInCell(); // no usable target
         
             MWBase::Environment::get().getSoundManager()->playSound3D(local ? actor : mTarget,
                 mSoundId, 1.0, 1.0, MWBase::SoundManager::Play_TypeSfx,
-                mKeepSound ? MWBase::SoundManager::Play_NoTrack : MWBase::SoundManager::Play_Normal);
+                mKeepSound ? MWBase::SoundManager::Play_NoTrack : MWBase::SoundManager::Play_Normal,
+                        mSoundOffset);
         }
     }
 
@@ -38,4 +40,9 @@ void MWWorld::Action::execute (const Ptr& actor)
 void MWWorld::Action::setSound (const std::string& id)
 {
     mSoundId = id;
+}
+
+void MWWorld::Action::setSoundOffset(float offset)
+{
+    mSoundOffset=offset;
 }

--- a/apps/openmw/mwworld/action.hpp
+++ b/apps/openmw/mwworld/action.hpp
@@ -12,6 +12,7 @@ namespace MWWorld
     {
             std::string mSoundId;
             bool mKeepSound;
+            float mSoundOffset;
             Ptr mTarget;
 
             // not implemented
@@ -34,6 +35,7 @@ namespace MWWorld
             void execute (const Ptr& actor);
 
             void setSound (const std::string& id);
+            void setSoundOffset(float offset);
     };
 }
 


### PR DESCRIPTION
That is basically the same I started before, but with resolved conflicts, offset parameter moved to the end and added fadeout instead of just stopping the sound. Hope everytjing is ok now.
