### PR TITLE
Allow the 'Activate' key to close the countdialog window

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -215,6 +215,7 @@ namespace MWBase
             virtual void removeStaticMessageBox() = 0;
 
             virtual void enterPressed () = 0;
+            virtual void activateKeyPressed () = 0;
             virtual int readPressedButton() = 0;
             ///< returns the index of the pressed button or -1 if no button was pressed (->MessageBoxmanager->InteractiveMessageBox)
 

--- a/apps/openmw/mwgui/countdialog.cpp
+++ b/apps/openmw/mwgui/countdialog.cpp
@@ -49,9 +49,14 @@ namespace MWGui
         mItemEdit->setCaption(boost::lexical_cast<std::string>(maxCount));
     }
 
-    void CountDialog::onCancelButtonClicked(MyGUI::Widget* _sender)
+    void CountDialog::cancel()
     {
         setVisible(false);
+    }
+
+    void CountDialog::onCancelButtonClicked(MyGUI::Widget* _sender)
+    {
+        cancel();
     }
 
     void CountDialog::onOkButtonClicked(MyGUI::Widget* _sender)

--- a/apps/openmw/mwgui/countdialog.hpp
+++ b/apps/openmw/mwgui/countdialog.hpp
@@ -10,6 +10,7 @@ namespace MWGui
         public:
             CountDialog();
             void open(const std::string& item, const std::string& message, const int maxCount);
+            void cancel();
 
             typedef MyGUI::delegates::CMultiDelegate2<MyGUI::Widget*, int> EventHandle_WidgetInt;
 
@@ -25,7 +26,7 @@ namespace MWGui
             MyGUI::TextBox* mLabelText;
             MyGUI::Button* mOkButton;
             MyGUI::Button* mCancelButton;
-	    
+
             void onCancelButtonClicked(MyGUI::Widget* _sender);
             void onOkButtonClicked(MyGUI::Widget* _sender);
             void onEditTextChange(MyGUI::EditBox* _sender);

--- a/apps/openmw/mwgui/messagebox.cpp
+++ b/apps/openmw/mwgui/messagebox.cpp
@@ -146,10 +146,10 @@ namespace MWGui
         mMessageBoxSpeed = speed;
     }
 
-    void MessageBoxManager::enterPressed ()
+    void MessageBoxManager::okayPressed ()
     {
         if(mInterMessageBoxe != NULL)
-            mInterMessageBoxe->enterPressed();
+            mInterMessageBoxe->okayPressed();
     }
 
     int MessageBoxManager::readPressedButton ()
@@ -379,7 +379,7 @@ namespace MWGui
         }
     }
 
-    void InteractiveMessageBox::enterPressed()
+    void InteractiveMessageBox::okayPressed()
     {
 
         std::string ok = Misc::StringUtils::lowerCase(MyGUI::LanguageManager::getInstance().replaceTags("#{sOK}"));

--- a/apps/openmw/mwgui/messagebox.hpp
+++ b/apps/openmw/mwgui/messagebox.hpp
@@ -40,7 +40,7 @@ namespace MWGui
             bool removeMessageBox (MessageBox *msgbox);
             void setMessageBoxSpeed (int speed);
 
-            void enterPressed();
+            void okayPressed();
             int readPressedButton ();
 
             typedef MyGUI::delegates::CMultiDelegate1<int> EventHandle_Int;
@@ -82,7 +82,7 @@ namespace MWGui
     {
         public:
             InteractiveMessageBox (MessageBoxManager& parMessageBoxManager, const std::string& message, const std::vector<std::string>& buttons);
-            void enterPressed ();
+            void okayPressed ();
             void mousePressed (MyGUI::Widget* _widget);
             int readPressedButton ();
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -669,7 +669,7 @@ namespace MWGui
     void WindowManager::activateKeyPressed ()
     {
         mMessageBoxManager->okayPressed();
-        mCountDialog->setVisible(false);
+        mCountDialog->cancel();
     }
 
     int WindowManager::readPressedButton ()

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -663,7 +663,13 @@ namespace MWGui
 
     void WindowManager::enterPressed ()
     {
-        mMessageBoxManager->enterPressed();
+        mMessageBoxManager->okayPressed();
+    }
+
+    void WindowManager::activateKeyPressed ()
+    {
+        mMessageBoxManager->okayPressed();
+        mCountDialog->setVisible(false);
     }
 
     int WindowManager::readPressedButton ()

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -204,6 +204,7 @@ namespace MWGui
     virtual void staticMessageBox(const std::string& message);
     virtual void removeStaticMessageBox();
     virtual void enterPressed ();
+    virtual void activateKeyPressed ();
     virtual int readPressedButton (); ///< returns the index of the pressed button or -1 if no button was pressed (->MessageBoxmanager->InteractiveMessageBox)
 
     virtual void onFrame (float frameDuration);

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -204,13 +204,15 @@ namespace MWInput
             case A_Activate:
                 resetIdleTime();
 
-                if (mWindows.getMode() == MWGui::GM_Container) {
-                    toggleContainer (); 
-                } else if (MWBase::Environment::get().getWindowManager()->isGuiMode()) {
-                    MWBase::Environment::get().getWindowManager()->enterPressed();
-                } else {
-                    activate();
+                if (mWindows.isGuiMode())
+                {
+                    if (mWindows.getMode() == MWGui::GM_Container)
+                        toggleContainer ();
+                    else
+                        MWBase::Environment::get().getWindowManager()->activateKeyPressed();
                 }
+                else
+                    activate();
                 break;
             case A_Journal:
                 toggleJournal ();
@@ -681,10 +683,8 @@ namespace MWInput
         if (MyGUI::InputManager::getInstance ().isModalAny())
             return;
 
-        bool gameMode = !mWindows.isGuiMode();
-
         // Toggle between game mode and inventory mode
-        if(gameMode)
+        if(!mWindows.isGuiMode())
             mWindows.pushGuiMode(MWGui::GM_Inventory);
         else
         {
@@ -701,9 +701,7 @@ namespace MWInput
         if (MyGUI::InputManager::getInstance ().isModalAny())
             return;
 
-        bool gameMode = !mWindows.isGuiMode();
-
-        if(!gameMode)
+        if(mWindows.isGuiMode())
         {
             if (mWindows.getMode() == MWGui::GM_Container)
                 mWindows.popGuiMode();
@@ -713,17 +711,14 @@ namespace MWInput
 
     }
 
-
     void InputManager::toggleConsole()
     {
         if (MyGUI::InputManager::getInstance ().isModalAny())
             return;
 
-        bool gameMode = !mWindows.isGuiMode();
-
         // Switch to console mode no matter what mode we are currently
         // in, except of course if we are already in console mode
-        if (!gameMode)
+        if (mWindows.isGuiMode())
         {
             if (mWindows.getMode() == MWGui::GM_Console)
                 mWindows.popGuiMode();
@@ -740,9 +735,7 @@ namespace MWInput
             return;
 
         // Toggle between game mode and journal mode
-        bool gameMode = !mWindows.isGuiMode();
-
-        if(gameMode && MWBase::Environment::get().getWindowManager ()->getJournalAllowed())
+        if(!mWindows.isGuiMode() && MWBase::Environment::get().getWindowManager ()->getJournalAllowed())
         {
             MWBase::Environment::get().getSoundManager()->playSound ("book open", 1.0, 1.0);
             mWindows.pushGuiMode(MWGui::GM_Journal);


### PR DESCRIPTION
and small cleanups

https://bugs.openmw.org/issues/786
