### PR TITLE
Bug #799 Enchanting window area slider

### DIFF
--- a/apps/openmw/mwgui/spellcreationdialog.cpp
+++ b/apps/openmw/mwgui/spellcreationdialog.cpp
@@ -163,7 +163,7 @@ namespace MWGui
             mDurationBox->setVisible (true);
             curY += mDurationBox->getSize().height;
         }
-        if (mEffect.mRange == ESM::RT_Target)
+        if (mEffect.mRange != ESM::RT_Self)
         {
             mAreaBox->setPosition(mAreaBox->getPosition().left, curY);
             mAreaBox->setVisible (true);
@@ -182,9 +182,6 @@ namespace MWGui
         else if (mEffect.mRange == ESM::RT_Touch)
             mRangeButton->setCaptionWithReplacing ("#{sRangeTouch}");
 
-        mAreaSlider->setVisible (mEffect.mRange != ESM::RT_Self);
-        mAreaText->setVisible (mEffect.mRange != ESM::RT_Self);
-
         // cycle through range types until we find something that's allowed
         if (mEffect.mRange == ESM::RT_Target && !(mMagicEffect->mData.mFlags & ESM::MagicEffect::CastTarget))
             onRangeButtonClicked(sender);
@@ -193,6 +190,11 @@ namespace MWGui
         if (mEffect.mRange == ESM::RT_Touch && !(mMagicEffect->mData.mFlags & ESM::MagicEffect::CastTouch))
             onRangeButtonClicked(sender);
 
+        if(mEffect.mRange == ESM::RT_Self)
+        {
+            mAreaSlider->setScrollPosition(0);
+            onAreaChanged(mAreaSlider,0);
+        }
         updateBoxes();
     }
 

--- a/apps/openmw/mwgui/spellcreationdialog.hpp
+++ b/apps/openmw/mwgui/spellcreationdialog.hpp
@@ -75,6 +75,7 @@ namespace MWGui
 
     protected:
         ESM::ENAMstruct mEffect;
+        ESM::ENAMstruct mOldEffect;
 
         const ESM::MagicEffect* mMagicEffect;
     };


### PR DESCRIPTION
http://bugs.openmw.org/issues/799
Area slider is now visible in touch and target mode, and resets to 0 if self is chosen, so the cost i calculated correctly. Every change in the spell effect dialog changes the costs instantly (before the cost was shown only after pressing OK).

Note, that constant enchantment part is left untouched, because I don't know yet how it works in vanilla (absorb health on self and area?!).
