### PR TITLE
Saner inventory window pinning/hiding

### DIFF
--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -94,16 +94,20 @@ namespace MWGui
         mGuiMode = mode;
         switch(mode) {
             case GM_Container:
+                setPinButtonVisible(false);
                 mMainWidget->setCoord(mPositionContainer);
                 break;
             case GM_Companion:
+                setPinButtonVisible(false);
                 mMainWidget->setCoord(mPositionCompanion);
                 break;
             case GM_Barter:
+                setPinButtonVisible(false);
                 mMainWidget->setCoord(mPositionBarter);
                 break;
             case GM_Inventory:
             default:
+                setPinButtonVisible(true);
                 mMainWidget->setCoord(mPositionInventory);
                 break;
         }

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -373,6 +373,7 @@ namespace MWGui
         {
             mMap->setVisible(mMap->pinned());
             mStatsWindow->setVisible(mStatsWindow->pinned());
+            mInventoryWindow->setGuiMode(GM_None);
             mInventoryWindow->setVisible(mInventoryWindow->pinned());
             mSpellWindow->setVisible(mSpellWindow->pinned());
 
@@ -1117,6 +1118,9 @@ namespace MWGui
 
     void WindowManager::toggleVisible (GuiWindow wnd)
     {
+        if (getMode() != GM_Inventory)
+            return;
+
         mShown = (mShown & wnd) ? (GuiWindow) (mShown & ~wnd) : (GuiWindow) (mShown | wnd);
         updateVisible();
     }

--- a/apps/openmw/mwgui/windowpinnablebase.cpp
+++ b/apps/openmw/mwgui/windowpinnablebase.cpp
@@ -5,7 +5,7 @@
 namespace MWGui
 {
     WindowPinnableBase::WindowPinnableBase(const std::string& parLayout)
-      : WindowBase(parLayout), mPinned(false), mVisible(false)
+      : WindowBase(parLayout), mPinned(false)
     {
         ExposedWindow* window = static_cast<ExposedWindow*>(mMainWidget);
         mPinButton = window->getSkinWidget ("Button");
@@ -23,5 +23,10 @@ namespace MWGui
             mPinButton->changeWidgetSkin ("PinUp");
 
         onPinToggled();
+    }
+
+    void WindowPinnableBase::setPinButtonVisible(bool visible)
+    {
+        mPinButton->setVisible(visible);
     }
 }

--- a/apps/openmw/mwgui/windowpinnablebase.hpp
+++ b/apps/openmw/mwgui/windowpinnablebase.hpp
@@ -12,6 +12,7 @@ namespace MWGui
     public:
         WindowPinnableBase(const std::string& parLayout);
         bool pinned() { return mPinned; }
+        void setPinButtonVisible(bool visible);
 
     private:
         void onPinButtonClicked(MyGUI::Widget* _sender);
@@ -21,7 +22,6 @@ namespace MWGui
 
         MyGUI::Widget* mPinButton;
         bool mPinned;
-        bool mVisible;
     };
 }
 


### PR DESCRIPTION
Hide inventory window pin button in container, companion and barter mode.
Restore the pinned inventory window position when exiting these modes.
Allow toggling windows visibility in inventory mode only.
