### PR TITLE
Layout updates 2

### DIFF
--- a/files/mygui/openmw_alchemy_window.layout
+++ b/files/mygui/openmw_alchemy_window.layout
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 588 414" name="_Main">
+    <Widget type="Window" skin="MW_Window_NoCaption" layer="Windows" position="0 0 588 444" name="_Main">
+       <Property key="MinSize" value="420 360"/>
 
         <!-- Name -->
 
@@ -10,7 +11,7 @@
             <Property key="TextAlign" value="Left"/>
         </Widget>
 
-        <Widget type="EditBox" skin="MW_TextEdit" position="70 10 500 24" name="NameEdit"/>
+        <Widget type="EditBox" skin="MW_TextEdit" position="70 10 492 24" align="Top Left HStretch" name="NameEdit"/>
 
 
         <!-- Apparatus -->
@@ -71,7 +72,7 @@
 
         <!-- Available Ingredients -->
 
-        <Widget type="ItemView" skin="MW_ItemView" position="10 206 560 158" name="ItemView" align="Left Top Stretch"/>
+        <Widget type="ItemView" skin="MW_ItemView" position="10 206 552 158" name="ItemView" align="Left Top Stretch"/>
 
 
         <!-- Created Effects -->
@@ -81,14 +82,14 @@
             <Property key="TextAlign" value="Left"/>
         </Widget>
 
-        <Widget type="Widget" skin="MW_Box" position="250 66 320 130">
-            <Widget type="Widget" skin="" position="4 4 316 122" name="CreatedEffects"/>
+        <Widget type="Widget" skin="MW_Box" position="250 66 312 130" align="Top Left HStretch">
+            <Widget type="Widget" skin="" position="4 4 316 122" name="CreatedEffects" align="HStretch"/>
         </Widget>
 
 
         <!-- Buttons -->
 
-        <Widget type="HBox" skin="" position="110 372 460 24">
+        <Widget type="HBox" skin="" position="110 374 452 24" align="Bottom Right">
 
             <Widget type="Widget">
                 <UserString key="HStretch" value="true"/>

--- a/files/mygui/openmw_book.layout
+++ b/files/mygui/openmw_book.layout
@@ -41,8 +41,8 @@
             <Property key="TextColour" value="0 0 0"/>
         </Widget>
 
-        <Widget type="Widget" skin="" position="30 22 240 300" name = "LeftPage"/>
-        <Widget type="Widget" skin="" position="300 22 240 300" name = "RightPage"/>
+        <Widget type="Widget" skin="" position="30 22 240 300" name="LeftPage"/>
+        <Widget type="Widget" skin="" position="300 22 240 300" name="RightPage"/>
     </Widget>
     </Widget>
 </Widget>

--- a/files/mygui/openmw_box.skin.xml
+++ b/files/mygui/openmw_box.skin.xml
@@ -42,23 +42,23 @@ as around the sections of the stats window, or around popup info windows -->
         </BasisSkin>
     </Skin>
     <Skin name="IB_TL" size="2 2" texture="textures\menu_thin_border_top_left_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="IB_TR" size="2 2" texture="textures\menu_thin_border_top_right_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="IB_BL" size="2 2" texture="textures\menu_thin_border_bottom_left_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="IB_BR" size="2 2" texture="textures\menu_thin_border_bottom_right_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
 

--- a/files/mygui/openmw_button.skin.xml
+++ b/files/mygui/openmw_button.skin.xml
@@ -39,30 +39,30 @@
         </BasisSkin>
     </Skin>
     <Skin name="BTN_TopLeft" size="4 4" texture="textures\menu_button_frame_top_left_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="BTN_TopRight" size="4 4" texture="textures\menu_button_frame_top_right_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="BTN_BottomLeft" size="4 4" texture="textures\menu_button_frame_bottom_left_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="BTN_BottomRight" size="4 4" texture="textures\menu_button_frame_bottom_right_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
 
     <!-- Button widget -->
     <Skin name="MW_Button" size="136 24">
-        <Property key="FontName" value = "Default"/>
-        <Property key="TextAlign" value = "Center" />
+        <Property key="FontName" value="Default"/>
+        <Property key="TextAlign" value="Center" />
 
         <Child type="Widget" skin="BTN_Left" offset="0 4 4 16" align="VStretch Left"/>
         <Child type="Widget" skin="BTN_Right" offset="132 4 4 16" align="VStretch Right"/>

--- a/files/mygui/openmw_chargen_class_description.layout
+++ b/files/mygui/openmw_chargen_class_description.layout
@@ -5,9 +5,9 @@
 
         <!-- Edit box -->
 
-        <Widget type="Widget" skin="MW_Box" position="14 14 220 192" align="Stretch" name = "Client"/>
+        <Widget type="Widget" skin="MW_Box" position="14 14 220 192" align="Stretch" name="Client"/>
 
-        <Widget type="EditBox" skin="MW_TextBoxEdit" position="14 14 220 192" name="TextEdit" align="Left Top STRETCH">
+        <Widget type="EditBox" skin="MW_TextBoxEdit" position="14 14 220 192" name="TextEdit" align="Left Top Stretch">
             <Property key="MultiLine" value="1" />
             <Property key="VisibleVScroll" value="1" />
             <Property key="WordWrap" value="1" />

--- a/files/mygui/openmw_companion_window.layout
+++ b/files/mygui/openmw_companion_window.layout
@@ -2,6 +2,7 @@
 
 <MyGUI type="Layout">
     <Widget type="Window" skin="MW_Window" layer="Windows" position="0 0 600 300" name="_Main">
+        <Property key="MinSize" value="245 145"/>
 
         <!-- Items -->
         <Widget type="ItemView" skin="MW_ItemView" position="5 5 575 225" name="ItemView" align="Left Top Stretch">

--- a/files/mygui/openmw_confirmation_dialog.layout
+++ b/files/mygui/openmw_confirmation_dialog.layout
@@ -5,9 +5,9 @@
         <Property key="Visible" value="false"/>
 
         <Widget type="EditBox" skin="MW_TextEditClient" position="8 8 284 400" name="Message" align="Left Top Stretch">
-            <Property key="FontName" value = "Default" />
+            <Property key="FontName" value="Default" />
             <Property key="TextAlign" value="Top HCenter" />
-            <Property key="TextColour" value = "0.75 0.6 0.35" />
+            <Property key="TextColour" value="0.75 0.6 0.35" />
             <Property key="Static" value="true"/>
             <Property key="WordWrap" value="true"/>
             <Property key="MultiLine" value="true" />

--- a/files/mygui/openmw_console.layout
+++ b/files/mygui/openmw_console.layout
@@ -2,17 +2,17 @@
 <MyGUI type="Layout">
   <Widget type="Window" skin="MW_Window" position="0 0 400 400" layer="Console" name="_Main">
     <Property key="Caption" value="#{sConsoleTitle}"/>
-    <Property key="MinSize" value="200 100"/>
+    <Property key="MinSize" value="405 245"/>
     <Property key="MaxSize" value="2000 2000"/>
     <Property key="Visible" value="false"/>
 
     <!-- Log window -->
-    <Widget type="EditBox" skin="MW_ConsoleLog" position="5 5 380 330" align="Stretch" name="list_History">
+    <Widget type="EditBox" skin="MW_ConsoleLog" position="5 5 380 328" align="Stretch" name="list_History">
         <Property key="MultiLine" value="1"/>
     </Widget>
 
     <!-- Command line -->
-    <Widget type="EditBox" skin="MW_ConsoleCommand" position="0 335 382 28" align="HStretch Bottom" name="edit_Command"/>
+    <Widget type="EditBox" skin="MW_ConsoleCommand" position="2 335 380 28" align="HStretch Bottom" name="edit_Command"/>
 
   </Widget>
 </MyGUI>

--- a/files/mygui/openmw_console.skin.xml
+++ b/files/mygui/openmw_console.skin.xml
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Skin">
-    <Skin name = "MW_LogClient" size = "10 10">
-        <Property key="FontName" value = "MonoFont" />
-        <Property key="TextAlign" value = "Left Top" />
-        <Property key="TextColour" value = "1 1 1" />
-        <!--Property key="Pointer" value = "beam" /-->
-        <BasisSkin type="EditText" offset = "0 0 10 10" align = "Stretch"/>
+    <Skin name="MW_LogClient" size="10 10">
+        <Property key="FontName" value="MonoFont" />
+        <Property key="TextAlign" value="Left Top" />
+        <Property key="TextColour" value="1 1 1" />
+        <BasisSkin type="EditText" offset="0 0 10 10" align="Stretch"/>
     </Skin>
 
     <!-- The edit control used for entering commands -->
-    <Skin name = "MW_ConsoleCommand" size = "29 26">
-        <Child type="TextBox" skin="MW_EditClient" offset = "2 1 23 22" align = "Stretch" name = "Client"/>
+    <Skin name="MW_ConsoleCommand" size="29 28">
+        <Child type="TextBox" skin="MW_EditClient" offset="2 1 23 22" align="Bottom Stretch" name="Client"/>
 
-        <Child type="Widget" skin="MW_BarFrame" offset="0 0 29 26" align="Stretch"/>
+        <Child type="Widget" skin="MW_Box" offset="0 0 29 26" align="Bottom Stretch"/>
     </Skin>
 
     <Skin name="MW_ConsoleLog" size="0 0 50 50">
-        <Property key="WordWrap" value = "true" />
-        <Child type="TextBox" skin="MW_LogClient" offset="0 0 35 10" align = "Stretch" name = "Client"/>
-        <!--Child type="VScroll" skin="VScroll" offset = "35 0 15 50" align = "Right VStretch" name = "VScroll"/-->
+        <Property key="WordWrap" value="true" />
+        <Child type="TextBox" skin="MW_LogClient" offset="0 0 35 10" align="Stretch" name="Client"/>
     </Skin>
 
-    <Skin name = "MW_EditClient" size = "10 10">
-        <Property key="FontName" value = "MonoFont" />
-        <Property key="TextAlign" value = "Left VCenter" />
-        <Property key="TextColour" value = "1 1 1" />
-        <!--Property key="Pointer" value = "beam" /-->
-        <BasisSkin type="EditText" offset = "0 0 10 10" align = "Stretch"/>
+    <Skin name="MW_EditClient" size="10 10">
+        <Property key="FontName" value="MonoFont" />
+        <Property key="TextAlign" value="Left VCenter" />
+        <Property key="TextColour" value="1 1 1" />
+        <!--Property key="Pointer" value="beam" /-->
+        <BasisSkin type="EditText" offset="0 0 10 10" align="Stretch"/>
     </Skin>
 </MyGUI>

--- a/files/mygui/openmw_container_window.layout
+++ b/files/mygui/openmw_container_window.layout
@@ -2,6 +2,7 @@
 
 <MyGUI type="Layout">
     <Widget type="Window" skin="MW_Window" layer="Windows" position="0 0 600 300" name="_Main">
+        <Property key="MinSize" value="245 145"/>
 
         <!-- Items -->
         <Widget type="ItemView" skin="MW_ItemView" position="5 5 575 225" name="ItemView" align="Left Top Stretch">

--- a/files/mygui/openmw_dialogue_window.layout
+++ b/files/mygui/openmw_dialogue_window.layout
@@ -2,8 +2,9 @@
 
 <MyGUI type="Layout">
     <Widget type="Window" skin="MW_Window" layer="Windows" position="0 0 588 433" name="_Main">
+        <Property key="MinSize" value="380 230"/>
 
-        <Widget type="Widget" skin="MW_Box" position="8 8 415 381" align="Stretch" name = "Client"/>
+        <Widget type="Widget" skin="MW_Box" position="8 8 415 381" align="Stretch" name="Client"/>
 
         <Widget type="Widget" position="13 13 391 371" align="Left Top Stretch">
             <Widget type="BookPage" skin="MW_BookPage" position="0 0 391 371" name="History" align="Left Top Stretch">
@@ -17,7 +18,7 @@
 		<!-- The disposition bar-->
         <Widget type="ProgressBar" skin="MW_EnergyBar_Blue" position="432 8 132 18"
             align="Right Top" name="Disposition">
-			<Widget type="EditBox" skin="MW_DispositionEdit" position_real = "0 0 1 1" align="Stretch" name = "DispositionText"/>
+			<Widget type="EditBox" skin="MW_DispositionEdit" position_real="0 0 1 1" align="Stretch" name="DispositionText"/>
 		</Widget>
         <!-- The list of topics -->
         <Widget type="MWList" skin="MW_SimpleList" position="432 31 132 328" name="TopicsList" align="Right VStretch">

--- a/files/mygui/openmw_dialogue_window_skin.xml
+++ b/files/mygui/openmw_dialogue_window_skin.xml
@@ -2,18 +2,18 @@
 
 <MyGUI type="Skin">
 
-    <Skin name = "MW_DispEdit" size = "10 10">
-        <!--Property key="Pointer" value = "beam" /-->
-        <BasisSkin type="EditText" offset = "0 0 10 10" align = "Stretch"/>
+    <Skin name="MW_DispEdit" size="10 10">
+        <!--Property key="Pointer" value="beam" /-->
+        <BasisSkin type="EditText" offset="0 0 10 10" align="Stretch"/>
     </Skin>
 
     <Skin name="MW_DispositionEdit" size="0 0 50 50">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Center" />
-        <Property key="Colour" value = "0000FF" />
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Center" />
+        <Property key="Colour" value="0000FF" />
         <Property key="Static" value="1" />
-        <Property key="WordWrap" value = "true" />
-        <Child type="TextBox" skin="MW_DispEdit" offset="0 0 0 -4" align = "Stretch" name = "Client"/>
+        <Property key="WordWrap" value="true" />
+        <Child type="TextBox" skin="MW_DispEdit" offset="0 0 0 -4" align="Stretch" name="Client"/>
     </Skin>
-    
+
 </MyGUI>

--- a/files/mygui/openmw_edit.skin.xml
+++ b/files/mygui/openmw_edit.skin.xml
@@ -4,15 +4,15 @@
 
     <!-- Text edit widget -->
 
-    <Skin name = "MW_TextEditClient" size = "10 10">
+    <Skin name="MW_TextEditClient" size="10 10">
 
-        <BasisSkin type="EditText" offset = "0 0 10 10" align = "Stretch"/>
+        <BasisSkin type="EditText" offset="0 0 10 10" align="Stretch"/>
 
     </Skin>
 
-    <Skin name = "MW_TextBoxEditClient" size = "10 10">
+    <Skin name="MW_TextBoxEditClient" size="10 10">
 
-        <BasisSkin type="EditText" offset = "0 0 10 10" align = "Stretch"/>
+        <BasisSkin type="EditText" offset="0 0 10 10" align="Stretch"/>
 
     </Skin>
 
@@ -20,13 +20,13 @@
 
         <!-- Input -->
 
-        <Property key="FontName" value = "Default"/>
+        <Property key="FontName" value="Default"/>
 
-        <Property key="TextAlign" value = "Left VCenter" />
+        <Property key="TextAlign" value="Left VCenter" />
 
-        <Property key="TextColour" value = "0.75 0.6 0.35" />
+        <Property key="TextColour" value="0.75 0.6 0.35" />
 
-        <Child type="TextBox" skin="MW_TextEditClient" offset = "2 2 508 18" align = "Stretch" name = "Client"/>
+        <Child type="TextBox" skin="MW_TextEditClient" offset="2 2 508 18" align="Stretch" name="Client"/>
 
 
         <!-- Borders -->
@@ -37,15 +37,15 @@
 
     <Skin name="MW_TextBoxEdit" size="512 20">
 
-        <Property key="FontName" value = "Default"/>
+        <Property key="FontName" value="Default"/>
 
-        <Property key="TextAlign" value = "Left Top" />
+        <Property key="TextAlign" value="Left Top" />
 
-        <Property key="TextColour" value = "0.75 0.6 0.35" />
+        <Property key="TextColour" value="0.75 0.6 0.35" />
 
-        <Child type="TextBox" skin="MW_TextBoxEditClient" offset = "2 2 490 18" align = "Stretch" name = "Client"/>
+        <Child type="TextBox" skin="MW_TextBoxEditClient" offset="2 2 490 18" align="Stretch" name="Client"/>
 
-        <Child type="MWScrollBar" skin="MW_VScroll" offset = "494 3 14 14" align = "Right VStretch" name = "VScroll"/>
+        <Child type="MWScrollBar" skin="MW_VScroll" offset="494 3 14 14" align="Right VStretch" name="VScroll"/>
 
     </Skin>
 

--- a/files/mygui/openmw_hud.layout
+++ b/files/mygui/openmw_hud.layout
@@ -32,7 +32,7 @@
                 <Property key="NeedMouse" value="false"/>
             </Widget>
         </Widget>
-        
+
         <!-- Drowning bar -->
         <Widget type="Widget" skin="HUD_Box" position="0 36 220 56" align="Center Top" name="DrowningFrame">
             <Property key="Visible" value="false"/>
@@ -46,7 +46,7 @@
                 <Property key="NeedMouse" value="false"/>
             </Widget>
         </Widget>
-        
+
         <!-- Equipped weapon/selected spell name display for a few seconds after it changes -->
         <Widget type="TextBox" skin="SandText" position="13 118 270 24" name="WeaponSpellName" align="Left Bottom HStretch">
             <Property key="Visible" value="false"/>

--- a/files/mygui/openmw_hud_energybar.skin.xml
+++ b/files/mygui/openmw_hud_energybar.skin.xml
@@ -3,83 +3,75 @@
 <MyGUI type="Skin">
     <!-- Energy bar frame graphics -->
     <Skin name="HUD_Bar_Top" size="64 2" texture="textures\menu_small_energy_bar_top.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 64 2">
-            <State name="normal" offset = "0 0 64 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 64 2">
+            <State name="normal" offset="0 0 64 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="HUD_Bar_Bottom" size="64 2" texture="textures\menu_small_energy_bar_bottom.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 64 2">
-            <State name="normal" offset = "0 0 64 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 64 2">
+            <State name="normal" offset="0 0 64 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="HUD_Bar_Side" size="2 8" texture="textures\menu_small_energy_bar_vert.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 8">
-            <State name="normal" offset = "0 0 2 8"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 8">
+            <State name="normal" offset="0 0 2 8"/>
         </BasisSkin>
-    </Skin>
-
-    <Skin name="MW_BarFrame" size="64 12">
-        <!-- Edges -->
-        <Child type="Widget" skin="HUD_Bar_Top" offset="0 0 64 2" align="HStretch Top"/>
-        <Child type="Widget" skin="HUD_Bar_Bottom" offset="0 10 64 2" align="HStretch Bottom"/>
-        <Child type="Widget" skin="HUD_Bar_Side" offset="0 2 2 8" align="VStretch Left"/>
-        <Child type="Widget" skin="HUD_Bar_Side" offset="62 2 2 8" align="VStretch Right"/>
     </Skin>
 
     <!-- Progress bar track, various colors -->
-    <Skin name = "MW_BarTrack_Red" size = "4 8" texture = "smallbars.png" >
-        <BasisSkin type="MainSkin" offset = "0 0 4 8" align = "Stretch">
-            <State name="normal" offset = "0 0 4 8"/>
+    <Skin name="MW_BarTrack_Red" size="4 8" texture="smallbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 4 8" align="Stretch">
+            <State name="normal" offset="0 0 4 8"/>
         </BasisSkin>
     </Skin>
-    <Skin name = "MW_BarTrack_Green" size = "4 8" texture = "smallbars.png" >
-        <BasisSkin type="MainSkin" offset = "0 0 4 8" align = "Stretch">
-            <State name="normal" offset = "0 16 4 8"/>
+    <Skin name="MW_BarTrack_Green" size="4 8" texture="smallbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 4 8" align="Stretch">
+            <State name="normal" offset="0 16 4 8"/>
         </BasisSkin>
     </Skin>
-    <Skin name = "MW_BarTrack_Blue" size = "4 8" texture = "smallbars.png" >
-        <BasisSkin type="MainSkin" offset = "0 0 4 8" align = "Stretch">
-            <State name="normal" offset = "0 8 4 8"/>
+    <Skin name="MW_BarTrack_Blue" size="4 8" texture="smallbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 4 8" align="Stretch">
+            <State name="normal" offset="0 8 4 8"/>
         </BasisSkin>
     </Skin>
-    <Skin name = "MW_BarTrack_Yellow" size = "4 8" texture = "smallbars.png" >
-        <BasisSkin type="MainSkin" offset = "0 0 4 8" align = "Stretch">
-            <State name="normal" offset = "0 32 4 8"/>
+    <Skin name="MW_BarTrack_Yellow" size="4 8" texture="smallbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 4 8" align="Stretch">
+            <State name="normal" offset="0 32 4 8"/>
         </BasisSkin>
     </Skin>
 
     <!-- Main energy bar widget definitions. There's one for each color.-->
 
     <Skin name="MW_EnergyBar_Red" size="64 12">
-        <Property key="TrackSkin" value = "MW_BarTrack_Red" />
-        <Property key="TrackWidth" value = "1" />
+        <Property key="TrackSkin" value="MW_BarTrack_Red" />
+        <Property key="TrackWidth" value="1" />
 
-        <Child type="Widget" skin="MW_BarFrame" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset = "2 2 60 8" align = "Stretch" name="Client"/>
+        <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
+        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Skin>
 
     <Skin name="MW_EnergyBar_Green" size="64 12">
-        <Property key="TrackSkin" value = "MW_BarTrack_Green" />
-        <Property key="TrackWidth" value = "1" />
+        <Property key="TrackSkin" value="MW_BarTrack_Green" />
+        <Property key="TrackWidth" value="1" />
 
-        <Child type="Widget" skin="MW_BarFrame" offset="0 0 64 12" align="Stretch"/>
+        <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
         <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Skin>
 
     <Skin name="MW_EnergyBar_Blue" size="64 12">
-        <Property key="TrackSkin" value = "MW_BarTrack_Blue" />
-        <Property key="TrackWidth" value = "1" />
+        <Property key="TrackSkin" value="MW_BarTrack_Blue" />
+        <Property key="TrackWidth" value="1" />
 
-        <Child type="Widget" skin="MW_BarFrame" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset = "2 2 60 8" align = "Stretch" name="Client"/>
+        <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
+        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Skin>
 
     <Skin name="MW_EnergyBar_Yellow" size="64 12">
-        <Property key="TrackSkin" value = "MW_BarTrack_Yellow" />
-        <Property key="TrackWidth" value = "1" />
+        <Property key="TrackSkin" value="MW_BarTrack_Yellow" />
+        <Property key="TrackWidth" value="1" />
 
-        <Child type="Widget" skin="MW_BarFrame" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset = "2 2 60 8" align = "Stretch" name="Client"/>
+        <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
+        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Skin>
 
 </MyGUI>

--- a/files/mygui/openmw_interactive_messagebox.layout
+++ b/files/mygui/openmw_interactive_messagebox.layout
@@ -2,10 +2,10 @@
 
 <MyGUI type="Layout">
     <Widget type="Window" skin="MW_Dialog" layer="Windows" position="0 0 500 400" name="_Main">
-        <Widget type="EditBox" skin="MW_TextEditClient" position="10 10 490 20" align="Left Top STRETCH" name="message">
-            <Property key="FontName" value = "Default" />
+        <Widget type="EditBox" skin="MW_TextEditClient" position="10 10 490 20" align="Left Top Stretch" name="message">
+            <Property key="FontName" value="Default" />
             <Property key="TextAlign" value="Center" />
-            <Property key="TextColour" value = "0.75 0.6 0.35" />
+            <Property key="TextColour" value="0.75 0.6 0.35" />
             <Property key="Static" value="true"/>
             <Property key="WordWrap" value="true"/>
             <Property key="MultiLine" value="1" />

--- a/files/mygui/openmw_inventory_window.layout
+++ b/files/mygui/openmw_inventory_window.layout
@@ -2,6 +2,7 @@
 
 <MyGUI type="Layout">
     <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 600 300" name="_Main">
+        <Property key="MinSize" value="470 235"/>
 
         <Widget type="Widget" skin="" position="0 0 224 223" align="Left Top" name="LeftPane">
 

--- a/files/mygui/openmw_journal_skin.xml
+++ b/files/mygui/openmw_journal_skin.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Skin">
-        <Skin name = "MW_BookClient" size = "10 10">
-                <Property key="FontName" value = "Default" />
-                <Property key="TextAlign" value = "Left Top" />
-                <Property key="TextColour" value = "0 0 0" />
-                <!--Property key="Pointer" value = "beam" /-->
-                <BasisSkin type="EditText" offset = "0 0 10 10" align = "Stretch"/>
+        <Skin name="MW_BookClient" size="10 10">
+                <Property key="FontName" value="Default" />
+                <Property key="TextAlign" value="Left Top" />
+                <Property key="TextColour" value="0 0 0" />
+                <!--Property key="Pointer" value="beam" /-->
+                <BasisSkin type="EditText" offset="0 0 10 10" align="Stretch"/>
         </Skin>
 
         <Skin name="MW_BookPage" size="0 0 50 50">

--- a/files/mygui/openmw_map_window.layout
+++ b/files/mygui/openmw_map_window.layout
@@ -2,6 +2,7 @@
 
 <MyGUI type="Layout">
     <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 300" name="_Main">
+        <Property key="MinSize" value="230 180"/>
 
         <!-- Local map -->
         <Widget type="ScrollView" skin="MW_MapView" position="0 0 284 264" align="Stretch" name="LocalMap">

--- a/files/mygui/openmw_messagebox.layout
+++ b/files/mygui/openmw_messagebox.layout
@@ -5,10 +5,10 @@
         <Widget type="TextBox" skin="TextBox" position="4 4 4 4" name="message" />
     </Widget-->
     <Widget type="Window" skin="MW_Dialog" layer="Notification" position="0 0 0 0" name="_Main">
-        <Widget type="EditBox" skin="MW_TextEditClient" position="5 -5 0 0" name="message"  align="Left Top STRETCH">
-            <Property key="FontName" value = "Default" />
+        <Widget type="EditBox" skin="MW_TextEditClient" position="5 -5 0 0" name="message"  align="Left Top Stretch">
+            <Property key="FontName" value="Default" />
             <Property key="TextAlign" value="Center" />
-            <Property key="TextColour" value = "0.75 0.6 0.35" />
+            <Property key="TextColour" value="0.75 0.6 0.35" />
             <Property key="Static" value="true"/>
             <Property key="WordWrap" value="true"/>
             <Property key="MultiLine" value="1" />

--- a/files/mygui/openmw_progress.skin.xml
+++ b/files/mygui/openmw_progress.skin.xml
@@ -2,66 +2,66 @@
 
 <MyGUI type="Skin">
     <!-- Progress bar track, various colors -->
-    <Skin name = "MW_BigTrack_Red" size = "2 14" texture = "bigbars.png" >
-        <BasisSkin type="MainSkin" offset = "0 0 2 14" align = "Stretch">
-            <State name="normal" offset = "0 0 2 14"/>
+    <Skin name="MW_BigTrack_Red" size="2 14" texture="bigbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 2 14" align="Stretch">
+            <State name="normal" offset="0 0 2 14"/>
         </BasisSkin>
     </Skin>
-    <Skin name = "MW_BigTrack_Blue" size = "2 14" texture = "bigbars.png" >
-        <BasisSkin type="MainSkin" offset = "0 0 2 14" align = "Stretch">
-            <State name="normal" offset = "0 14 2 14"/>
+    <Skin name="MW_BigTrack_Blue" size="2 14" texture="bigbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 2 14" align="Stretch">
+            <State name="normal" offset="0 14 2 14"/>
         </BasisSkin>
     </Skin>
-    <Skin name = "MW_BigTrack_Green" size = "2 14" texture = "bigbars.png" >
-        <BasisSkin type="MainSkin" offset = "0 0 2 14" align = "Stretch">
-            <State name="normal" offset = "0 28 2 14"/>
+    <Skin name="MW_BigTrack_Green" size="2 14" texture="bigbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 2 14" align="Stretch">
+            <State name="normal" offset="0 28 2 14"/>
         </BasisSkin>
     </Skin>
-	<Skin name = "MW_BigTrack_Progress_Blue_Small" size = "2 6" texture = "smallbars.png" >
-        <BasisSkin type="MainSkin" offset = "0 0 2 6" align = "Stretch">
-            <State name="normal" offset = "0 26 2 6"/>
+	<Skin name="MW_BigTrack_Progress_Blue_Small" size="2 6" texture="smallbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 2 6" align="Stretch">
+            <State name="normal" offset="0 26 2 6"/>
         </BasisSkin>
     </Skin>
 
-    <Skin name = "ProgressText" size = "16 16">
-        <Property key="FontName" value = "Default"/>
-        <Property key="TextAlign" value = "Center" />
-        <Property key="TextColour" value = "0.75 0.6 0.35" />
+    <Skin name="ProgressText" size="16 16">
+        <Property key="FontName" value="Default"/>
+        <Property key="TextAlign" value="Center" />
+        <Property key="TextColour" value="0.75 0.6 0.35" />
 
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch"/>
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch"/>
     </Skin>
 
     <!-- Main energy bar widget definitions. There's one for each color.-->
 
     <Skin name="MW_Progress_Red" size="64 12">
-        <Property key="TrackSkin" value = "MW_BigTrack_Red" />
-        <Property key="TrackWidth" value = "1" />
+        <Property key="TrackSkin" value="MW_BigTrack_Red" />
+        <Property key="TrackWidth" value="1" />
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset = "2 2 60 8" align = "Stretch" name="Client"/>
+        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Skin>
 
     <Skin name="MW_Progress_Green" size="64 12">
-        <Property key="TrackSkin" value = "MW_BigTrack_Green" />
-        <Property key="TrackWidth" value = "1" />
+        <Property key="TrackSkin" value="MW_BigTrack_Green" />
+        <Property key="TrackWidth" value="1" />
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset = "2 2 60 8" align = "Stretch" name="Client"/>
+        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Skin>
 
     <Skin name="MW_Progress_Blue" size="64 12">
-        <Property key="TrackSkin" value = "MW_BigTrack_Blue" />
-        <Property key="TrackWidth" value = "1" />
+        <Property key="TrackSkin" value="MW_BigTrack_Blue" />
+        <Property key="TrackWidth" value="1" />
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 12" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset = "2 2 60 8" align = "Stretch" name="Client"/>
+        <Child type="Widget" skin="BlackBG" offset="2 2 60 8" align="Stretch" name="Client"/>
     </Skin>
-	
+
 	<Skin name="MW_Progress_Loading" size="64 6">
-        <Property key="TrackSkin" value = "MW_BigTrack_Progress_Blue_Small" />
-        <Property key="TrackWidth" value = "1" />
+        <Property key="TrackSkin" value="MW_BigTrack_Progress_Blue_Small" />
+        <Property key="TrackWidth" value="1" />
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 6" align="Stretch"/>
-        <Child type="Widget" skin="BlackBG" offset = "2 2 60 2" align = "Stretch" name="Client"/>
+        <Child type="Widget" skin="BlackBG" offset="2 2 60 2" align="Stretch" name="Client"/>
     </Skin>
 </MyGUI>

--- a/files/mygui/openmw_resources.xml
+++ b/files/mygui/openmw_resources.xml
@@ -250,9 +250,21 @@
     <Resource type="ResourceLayout" name="TabControl" version="3.2.0">
         <Widget type="Widget" skin="" position="5 5 89 60" name="Root">
             <UserString key="ButtonSkin" value="MW_Button"/>
-            <Widget type="Widget" skin="MW_Box" position="0 24 89 36" align="Left Top Stretch">
+            <Widget type="Widget" skin="MW_Box" position="0 28 89 32" align="Left Top Stretch">
                 <Widget type="Widget" skin="" position="4 4 81 28" align="Left Top Stretch" name="TabItem"/>
             </Widget>
+            <Widget type="Widget" skin="" position="0 0 89 23" align="HStretch Top" name="HeaderPlace">
+                <Widget type="Widget" skin="" position="52 0 37 23" name="Controls">
+                </Widget>
+            </Widget>
+        </Widget>
+    </Resource>
+
+    <Resource type="ResourceLayout" name="TabControlInner" version="3.2.0">
+        <Widget type="Widget" skin="" position="0 5 89 60" name="Root">
+            <UserString key="ButtonSkin" value="MW_Button"/>
+            <Widget type="Widget" skin="" position="0 28 89 32" align="Left Top Stretch" name="TabItem"/>
+
             <Widget type="Widget" skin="" position="0 0 89 23" align="HStretch Top" name="HeaderPlace">
                 <Widget type="Widget" skin="" position="52 0 37 23" name="Controls">
                 </Widget>
@@ -263,10 +275,10 @@
     <Resource type="ResourceLayout" name="MW_StatNameValue" version="3.2.0">
         <Widget type="Widget" skin="" position="0 0 200 18" name="Root">
             <Property key="NeedMouse" value="true"/>
-            <Widget type="TextBox" skin="SandText" position = "0 0 160 18" align = "Left HStretch" name = "StatName">
+            <Widget type="TextBox" skin="SandText" position="0 0 160 18" align="Left HStretch" name="StatName">
                 <Property key="NeedMouse" value="false"/>
             </Widget>
-            <Widget type="TextBox" skin="SandTextRight" position = "160 0 40 18" align = "Right Top" name = "StatValue">
+            <Widget type="TextBox" skin="SandTextRight" position="160 0 40 18" align="Right Top" name="StatValue">
                 <Property key="NeedMouse" value="false"/>
             </Widget>
         </Widget>
@@ -283,7 +295,7 @@
 
     <Resource type="ResourceLayout" name="MW_StatNameButton" version="3.2.0">
         <Widget type="Widget" skin="" position="0 0 200 18" name="Root">
-            <Widget type="Button" skin="SandTextButton" position = "0 0 200 18" align = "Left HStretch" name = "StatNameButton">
+            <Widget type="Button" skin="SandTextButton" position="0 0 200 18" align="Left HStretch" name="StatNameButton">
                 <Property key="NeedMouse" value="true"/>
             </Widget>
         </Widget>

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <MyGUI type="Layout">
-    <Widget type="Window" skin="MW_Window_NoCaption" layer="Windows" position="0 0 400 414" name="_Main">
+    <Widget type="Window" skin="MW_Window_NoCaption" layer="Windows" position="0 0 400 426" name="_Main">
 
-        <Property key="MinSize" value="400 414"/>
-        <Property key="MaxSize" value="400 414"/>
+        <Property key="MinSize" value="400 426"/>
+        <Property key="MaxSize" value="400 426"/>
 
         <Widget type="TabControl" skin="TabControl" position="8 8 368 340" align="Left Top" name="SettingsTab">
             <Property key="ButtonAutoWidth" value="true"/>
@@ -112,8 +112,8 @@
             <Widget type="TabItem" skin="" position="4 28 360 312">
                 <Property key="Caption" value="  #{sControls}  "/>
 
-                <Widget type="Widget" skin="MW_Box" position="8 8 344 150">
-                    <Widget type="ScrollView" skin="MW_ScrollView" name="ControlsBox" position="4 4 336 142"/>
+                <Widget type="Widget" skin="MW_Box" position="4 4 352 154">
+                    <Widget type="ScrollView" skin="MW_ScrollView" name="ControlsBox" position="4 4 344 146"/>
                 </Widget>
 
                 <Widget type="AutoSizedButton" skin="MW_Button" name="ResetControlsButton" position="4 162 100 24">
@@ -149,13 +149,13 @@
             <Widget type="TabItem" skin="" position="4 28 360 312">
                 <Property key="Caption" value="  #{sVideo}  "/>
 
-                <Widget type="TabControl" skin="TabControl" position="4 4 352 304" align="Left Top">
+                <Widget type="TabControl" skin="TabControlInner" position="4 4 352 296" align="Left Top">
                     <Property key="ButtonAutoWidth" value="true"/>
 
                     <Widget type="TabItem" skin="" position="4 28 344 272">
                         <Property key="Caption" value="  Video  "/>
 
-                        <Widget type="ListBox" skin="MW_List" position="4 4 170 170" align="Left Top" name="ResolutionList"/>
+                        <Widget type="ListBox" skin="MW_List" position="0 4 170 170" align="Left Top" name="ResolutionList"/>
 
 
                         <Widget type="HBox" position="182 4 300 24">
@@ -193,18 +193,18 @@
                             </Widget>
                         </Widget>
 
-                        <Widget type="TextBox" skin="NormalText" position="4 198 329 18" align="Left Top" name="FovText">
+                        <Widget type="TextBox" skin="NormalText" position="0 198 329 18" align="Left Top" name="FovText">
                             <Property key="Caption" value="Field of View"/>
                         </Widget>
-                        <Widget type="MWScrollBar" skin="MW_HScroll" position="4 222 329 18" align="Left Top" name="FOVSlider">
+                        <Widget type="MWScrollBar" skin="MW_HScroll" position="0 222 329 18" align="Left Top" name="FOVSlider">
                             <Property key="Range" value="10000"/>
                             <Property key="Page" value="300"/>
                         </Widget>
-                        <Widget type="TextBox" skin="SandText" position="4 246 329 18" align="Left Top">
+                        <Widget type="TextBox" skin="SandText" position="0 246 329 18" align="Left Top">
                             <Property key="Caption" value="#{sLow}"/>
                             <Property key="TextAlign" value="Left"/>
                         </Widget>
-                        <Widget type="TextBox" skin="SandText" position="4 246 329 18" align="Left Top">
+                        <Widget type="TextBox" skin="SandText" position="0 246 329 18" align="Left Top">
                             <Property key="Caption" value="#{sHigh}"/>
                             <Property key="TextAlign" value="Right"/>
                         </Widget>
@@ -350,7 +350,7 @@
             </Widget>
         </Widget>
 
-        <Widget type="AutoSizedButton" skin="MW_Button" position="317 351 60 24" name="OkButton" align="Right Bottom">
+        <Widget type="AutoSizedButton" skin="MW_Button" position="317 355 60 24" name="OkButton" align="Right Bottom">
             <Property key="ExpandDirection" value="Left"/>
             <Property key="Caption" value="#{sOK}"/>
         </Widget>

--- a/files/mygui/openmw_spell_window.layout
+++ b/files/mygui/openmw_spell_window.layout
@@ -2,11 +2,11 @@
 
 <MyGUI type="Layout">
     <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 300 600" name="_Main">
+        <Property key="MinSize" value="260 250"/>
 
         <!-- Effect box-->
         <Widget type="Widget" skin="MW_Box" position="8 8 268 23" align="Left Top HStretch">
-            <Widget type="Widget" skin="" position="2 1 264 20" align="Left Top Stretch" name="EffectsBox">
-            </Widget>
+            <Widget type="Widget" skin="" position="2 1 264 20" align="Left Top Stretch" name="EffectsBox"/>
         </Widget>
 
         <!-- Spell list -->

--- a/files/mygui/openmw_stats_window.layout
+++ b/files/mygui/openmw_stats_window.layout
@@ -2,6 +2,7 @@
 
 <MyGUI type="Layout">
     <Widget type="ExposedWindow" skin="MW_Window_Pinnable" layer="Windows" position="0 0 500 342" name="_Main">
+        <Property key="MinSize" value="500 342"/>
 
         <Widget type="Widget" skin="" name="LeftPane" position="0 0 220 342">
 

--- a/files/mygui/openmw_text.skin.xml
+++ b/files/mygui/openmw_text.skin.xml
@@ -3,84 +3,84 @@
 <MyGUI type="Skin">
 
     <!-- HTML colour: #DDC79E -->
-    <Skin name = "NormalText" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Left Bottom" />
-        <Property key="TextColour" value = "0.87 0.78 0.62" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16" align = "Stretch"/>
+    <Skin name="NormalText" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Left Bottom" />
+        <Property key="TextColour" value="0.87 0.78 0.62" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16" align="Stretch"/>
     </Skin>
 
-    <Skin name = "NumFPS" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "HCenter Bottom" />
-        <Property key="TextColour" value = "1 1 1" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16" align = "Stretch"/>
+    <Skin name="NumFPS" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="HCenter Bottom" />
+        <Property key="TextColour" value="1 1 1" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16" align="Stretch"/>
     </Skin>
 
     <!-- HTML colour: #9A9074 -->
-    <Skin name = "SandTextGreyedOut" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Left Bottom" />
-        <Property key="TextColour" value = "0.6 0.56 0.45" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch"/>
+    <Skin name="SandTextGreyedOut" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Left Bottom" />
+        <Property key="TextColour" value="0.6 0.56 0.45" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch"/>
     </Skin>
 
     <!-- HTML colour: #BF9959 -->
-    <Skin name = "SandText" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Left Bottom" />
-        <Property key="TextColour" value = "0.75 0.6 0.35" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch"/>
+    <Skin name="SandText" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Left Bottom" />
+        <Property key="TextColour" value="0.75 0.6 0.35" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch"/>
     </Skin>
 
-    <Skin name = "SandTextC" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "TOP HCENTER" />
-        <Property key="TextColour" value = "0.75 0.6 0.35" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch"/>
+    <Skin name="SandTextC" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Top HCenter" />
+        <Property key="TextColour" value="0.75 0.6 0.35" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch"/>
     </Skin>
 
-    <Skin name = "SandTextRight" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Right Bottom" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch">
-            <State name="normal" colour = "0.75 0.6 0.35"/>
-            <State name="increased" colour = "0.757 0.679 0.539"/>
-            <State name="decreased" colour = "0.785 0.363 0.308"/>
+    <Skin name="SandTextRight" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Right Bottom" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch">
+            <State name="normal" colour="0.75 0.6 0.35"/>
+            <State name="increased" colour="0.757 0.679 0.539"/>
+            <State name="decreased" colour="0.785 0.363 0.308"/>
         </BasisSkin>
     </Skin>
 
-    <Skin name = "SandBrightText" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Left Bottom" />
-        <Property key="TextColour" value = "0.85 0.76 0.60" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch"/>
+    <Skin name="SandBrightText" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Left Bottom" />
+        <Property key="TextColour" value="0.85 0.76 0.60" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch"/>
     </Skin>
 
-    <Skin name = "DaedricText" size = "16 16">
-        <Property key="FontName" value = "daedric36" />
-        <Property key="FontHeight" value = "36" />
-        <Property key="TextAlign" value = "Default" />
-        <Property key="TextColour" value = "1 1 1" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch"/>
+    <Skin name="DaedricText" size="16 16">
+        <Property key="FontName" value="daedric36" />
+        <Property key="FontHeight" value="36" />
+        <Property key="TextAlign" value="Default" />
+        <Property key="TextColour" value="1 1 1" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch"/>
     </Skin>
 
-    <Skin name = "DaedricText_orig" size = "16 16">
-        <Property key="FontName" value = "daedric_orig36" />
-        <Property key="FontHeight" value = "36" />
-        <Property key="TextAlign" value = "Default" />
-        <Property key="TextColour" value = "1 1 1" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch"/>
+    <Skin name="DaedricText_orig" size="16 16">
+        <Property key="FontName" value="daedric_orig36" />
+        <Property key="FontHeight" value="36" />
+        <Property key="TextAlign" value="Default" />
+        <Property key="TextColour" value="1 1 1" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch"/>
     </Skin>
 
-    <Skin name = "MW_StatNameC" size = "200 18">
-        <Child type="TextBoxC" skin="SandText" offset = "0 0 200 18" align = "LEFT HSTRETCH" name = "StatName" />
+    <Skin name="MW_StatNameC" size="200 18">
+        <Child type="TextBoxC" skin="SandText" offset="0 0 200 18" align="Left HStretch" name="StatName" />
     </Skin>
 
-    <Skin name = "SandTextButtonC" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Top HCenter" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch">
+    <Skin name="SandTextButtonC" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Top HCenter" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch">
             <State name="disabled" colour="0.6 0.56 0.45" shift="0"/>
             <State name="normal" colour="0.75 0.6 0.35" shift="0"/>
             <State name="highlighted" colour="0.85 0.76 0.60" shift="0"/>
@@ -92,10 +92,10 @@
         </BasisSkin>
     </Skin>
 
-    <Skin name = "SandTextButton" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Left Bottom" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch">
+    <Skin name="SandTextButton" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Left Bottom" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch">
             <State name="disabled" colour="0.6 0.56 0.45" shift="0"/>
             <State name="normal" colour="0.75 0.6 0.35" shift="0"/>
             <State name="highlighted" colour="0.85 0.76 0.60" shift="0"/>
@@ -107,10 +107,10 @@
         </BasisSkin>
     </Skin>
 
-    <Skin name = "SpellText" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Left Bottom" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch">
+    <Skin name="SpellText" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Left Bottom" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch">
             <State name="disabled" colour="0.6 0.56 0.45" shift="0"/>
             <State name="normal" colour="0.75 0.6 0.35" shift="0"/>
             <State name="highlighted" colour="0.85 0.76 0.60" shift="0"/>
@@ -122,10 +122,10 @@
         </BasisSkin>
     </Skin>
 
-    <Skin name = "SpellTextUnequipped" size = "16 16">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Left Bottom" />
-        <BasisSkin type="SimpleText" offset = "0 0 16 16"  align = "Stretch">
+    <Skin name="SpellTextUnequipped" size="16 16">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Left Bottom" />
+        <BasisSkin type="SimpleText" offset="0 0 16 16"  align="Stretch">
             <State name="disabled" colour="0.6 0.56 0.45" shift="0"/>
             <State name="normal" colour="0.6 0.56 0.45" shift="0"/>
             <State name="highlighted" colour="0.85 0.76 0.60" shift="0"/>
@@ -137,47 +137,47 @@
         </BasisSkin>
     </Skin>
 
-    <Skin name = "MW_StatNameButtonC" size = "200 18">
-        <Child type="Button" skin="SandTextButtonC" offset = "0 0 200 18" align = "LEFT HSTRETCH" name = "StatNameButton" />
+    <Skin name="MW_StatNameButtonC" size="200 18">
+        <Child type="Button" skin="SandTextButtonC" offset="0 0 200 18" align="Left HStretch" name="StatNameButton" />
     </Skin>
 
 
 
-    <Skin name = "MW_StatNameValueButton" size = "200 18">
-        <Child type="Button" skin="SandText" offset = "0 0 160 18" align = "Left HStretch" name = "StatNameButton" />
-        <Child type="Button" skin="SandTextRight" offset = "160 0 40 18" align = "Right Top" name = "StatValueButton" />
+    <Skin name="MW_StatNameValueButton" size="200 18">
+        <Child type="Button" skin="SandText" offset="0 0 160 18" align="Left HStretch" name="StatNameButton" />
+        <Child type="Button" skin="SandTextRight" offset="160 0 40 18" align="Right Top" name="StatValueButton" />
     </Skin>
 
-    <Skin name = "MW_EffectImage" size = "200 24">
-        <Child type="ImageBox" skin="ImageBox" offset = "4 4 16 16" align = "Left Top" name = "Image" />
-        <Child type="TextBox" skin="SandText" offset = "24 0 176 20" align = "VCenter HStretch" name = "Text" />
+    <Skin name="MW_EffectImage" size="200 24">
+        <Child type="ImageBox" skin="ImageBox" offset="4 4 16 16" align="Left Top" name="Image" />
+        <Child type="TextBox" skin="SandText" offset="24 0 176 20" align="VCenter HStretch" name="Text" />
     </Skin>
 
-    <Skin name = "MW_ChargeBar" size = "204 18">
-        <Child type="ProgressBar" skin="MW_Progress_Red" offset = "0 0 204 18" align = "Right Top Stretch" name = "Bar" />
-        <Child type="TextBox" skin="SandTextC" offset = "0 0 204 18" align = "Right Top Stretch" name = "BarText" />
+    <Skin name="MW_ChargeBar" size="204 18">
+        <Child type="ProgressBar" skin="MW_Progress_Red" offset="0 0 204 18" align="Right Top Stretch" name="Bar" />
+        <Child type="TextBox" skin="SandTextC" offset="0 0 204 18" align="Right Top Stretch" name="BarText" />
     </Skin>
 
-    <Skin name = "MW_ChargeBar_Blue" size = "204 18">
-        <Child type="ProgressBar" skin="MW_Progress_Blue" offset = "0 0 204 18" align = "Right Top Stretch" name = "Bar" />
-        <Child type="TextBox" skin="SandTextC" offset = "0 0 204 18" align = "Right Top Stretch" name = "BarText" />
+    <Skin name="MW_ChargeBar_Blue" size="204 18">
+        <Child type="ProgressBar" skin="MW_Progress_Blue" offset="0 0 204 18" align="Right Top Stretch" name="Bar" />
+        <Child type="TextBox" skin="SandTextC" offset="0 0 204 18" align="Right Top Stretch" name="BarText" />
     </Skin>
 
-    <Skin name = "MW_DynamicStat_Red" size = "204 18">
-        <Child type="TextBox" skin="SandText" offset = "0 0 100 18" align = "Left Top" name = "Text" />
-        <Child type="ProgressBar" skin="MW_Progress_Red" offset = "74 0 130 18" align = "Right Top" name = "Bar" />
-        <Child type="TextBox" skin="SandTextC" offset = "74 0 130 18" align = "Right Top" name = "BarText" />
+    <Skin name="MW_DynamicStat_Red" size="204 18">
+        <Child type="TextBox" skin="SandText" offset="0 0 100 18" align="Left Top" name="Text" />
+        <Child type="ProgressBar" skin="MW_Progress_Red" offset="74 0 130 18" align="Right Top" name="Bar" />
+        <Child type="TextBox" skin="SandTextC" offset="74 0 130 18" align="Right Top" name="BarText" />
     </Skin>
 
-    <Skin name = "MW_DynamicStat_Blue" size = "204 18">
-        <Child type="TextBox" skin="SandText" offset = "0 0 100 18" align = "Left Top" name = "Text" />
-        <Child type="ProgressBar" skin="MW_Progress_Blue" offset = "74 0 130 18" align = "Right Top" name = "Bar" />
-        <Child type="TextBox" skin="SandTextC" offset = "74 0 130 18" align = "Right Top" name = "BarText" />
+    <Skin name="MW_DynamicStat_Blue" size="204 18">
+        <Child type="TextBox" skin="SandText" offset="0 0 100 18" align="Left Top" name="Text" />
+        <Child type="ProgressBar" skin="MW_Progress_Blue" offset="74 0 130 18" align="Right Top" name="Bar" />
+        <Child type="TextBox" skin="SandTextC" offset="74 0 130 18" align="Right Top" name="BarText" />
     </Skin>
 
-    <Skin name = "MW_DynamicStat_Green" size = "204 18">
-        <Child type="TextBox" skin="SandText" offset = "0 0 100 18" align = "Left Top" name = "Text" />
-        <Child type="ProgressBar" skin="MW_Progress_Green" offset = "74 0 130 18" align = "Right Top" name = "Bar" />
-        <Child type="TextBox" skin="SandTextC" offset = "74 0 130 18" align = "Right Top" name = "BarText" />
+    <Skin name="MW_DynamicStat_Green" size="204 18">
+        <Child type="TextBox" skin="SandText" offset="0 0 100 18" align="Left Top" name="Text" />
+        <Child type="ProgressBar" skin="MW_Progress_Green" offset="74 0 130 18" align="Right Top" name="Bar" />
+        <Child type="TextBox" skin="SandTextC" offset="74 0 130 18" align="Right Top" name="BarText" />
     </Skin>
 </MyGUI>

--- a/files/mygui/openmw_trade_window.layout
+++ b/files/mygui/openmw_trade_window.layout
@@ -3,6 +3,7 @@
 <MyGUI type="Layout">
     <Widget type="Window" skin="MW_Window" layer="Windows" position="0 0 600 360" name="_Main">
         <Property key="Visible" value="false"/>
+        <Property key="MinSize" value="380 245"/>
 
         <!-- Categories -->
         <Widget type="HBox" position="8 8 566 24" align="Left Top HStretch" name="Categories">

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -2,128 +2,128 @@
 
 <MyGUI type="Skin">
     <!-- Defines a transparent background -->
-    <Skin name = "BlackBG" size = "8 8" texture = "transparent.png">
-        <BasisSkin type="MainSkin" offset = "0 0 8 8">
-            <State name="normal" offset = "0 0 8 8"/>
+    <Skin name="BlackBG" size="8 8" texture="transparent.png">
+        <BasisSkin type="MainSkin" offset="0 0 8 8">
+            <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>
     </Skin>
 
     <!-- Define the borders for pin button (up) -->
     <Skin name="PU_B" size="12 2" texture="textures\menu_rightbuttonup_bottom.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 12 2">
-            <State name="normal" offset = "0 0 12 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 12 2">
+            <State name="normal" offset="0 0 12 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PU_BR" size="2 2" texture="textures\menu_rightbuttonup_bottom_right.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PU_R" size="2 12" texture="textures\menu_rightbuttonup_right.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 12">
-            <State name="normal" offset = "0 0 2 12"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 12">
+            <State name="normal" offset="0 0 2 12"/>
         </BasisSkin>
     </Skin>
     <Skin name="PU_TR" size="2 2" texture="textures\menu_rightbuttonup_top_right.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PU_T" size="12 2" texture="textures\menu_rightbuttonup_top.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 12 2">
-            <State name="normal" offset = "0 0 12 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 12 2">
+            <State name="normal" offset="0 0 12 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PU_TL" size="2 2" texture="textures\menu_rightbuttonup_top_left.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PU_L" size="2 12" texture="textures\menu_rightbuttonup_left.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 12">
-            <State name="normal" offset = "0 0 2 12"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 12">
+            <State name="normal" offset="0 0 2 12"/>
         </BasisSkin>
     </Skin>
     <Skin name="PU_BL" size="2 2" texture="textures\menu_rightbuttonup_bottom_left.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
 
     <!-- Define the borders for pin button (down) -->
     <Skin name="PD_B" size="12 2" texture="textures\menu_rightbuttondown_bottom.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 12 2">
-            <State name="normal" offset = "0 0 12 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 12 2">
+            <State name="normal" offset="0 0 12 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PD_BR" size="2 2" texture="textures\menu_rightbuttondown_bottom_right.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PD_R" size="2 12" texture="textures\menu_rightbuttondown_right.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 12">
-            <State name="normal" offset = "0 0 2 12"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 12">
+            <State name="normal" offset="0 0 2 12"/>
         </BasisSkin>
     </Skin>
     <Skin name="PD_TR" size="2 2" texture="textures\menu_rightbuttondown_top_right.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PD_T" size="12 2" texture="textures\menu_rightbuttondown_top.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 12 2">
-            <State name="normal" offset = "0 0 12 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 12 2">
+            <State name="normal" offset="0 0 12 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PD_TL" size="2 2" texture="textures\menu_rightbuttondown_top_left.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="PD_L" size="2 12" texture="textures\menu_rightbuttondown_left.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 12">
-            <State name="normal" offset = "0 0 2 12"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 12">
+            <State name="normal" offset="0 0 2 12"/>
         </BasisSkin>
     </Skin>
     <Skin name="PD_BL" size="2 2" texture="textures\menu_rightbuttondown_bottom_left.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
 
     <!-- Define the pin button skin -->
-    <Skin name = "PinUp" size = "19 19" texture="textures\menu_rightbuttonup_center.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 19 19">
-            <State name="normal" offset = "0 0 19 19"/>
+    <Skin name="PinUp" size="19 19" texture="textures\menu_rightbuttonup_center.dds">
+        <BasisSkin type="MainSkin" offset="0 0 19 19">
+            <State name="normal" offset="0 0 19 19"/>
         </BasisSkin>
-        <Child type="Widget" skin="PU_B"  offset="2 17 15 2" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PU_BR" offset="17 17 2 2" align="HStretch VStretch"/>
-				<Child type="Widget" skin="PU_R"  offset="17 2 2 15" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PU_TR" offset="17 0 2 2" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PU_T"  offset="2 0 15 2" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PU_TL" offset="0 0 2 2" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PU_L"  offset="0 2 2 15" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PU_BL" offset="0 17 2 2" align="HStretch VStretch"/>
+        <Child type="Widget" skin="PU_B"  offset="2 17 15 2" align="Stretch"/>
+        <Child type="Widget" skin="PU_BR" offset="17 17 2 2" align="Stretch"/>
+				<Child type="Widget" skin="PU_R"  offset="17 2 2 15" align="Stretch"/>
+        <Child type="Widget" skin="PU_TR" offset="17 0 2 2" align="Stretch"/>
+        <Child type="Widget" skin="PU_T"  offset="2 0 15 2" align="Stretch"/>
+        <Child type="Widget" skin="PU_TL" offset="0 0 2 2" align="Stretch"/>
+        <Child type="Widget" skin="PU_L"  offset="0 2 2 15" align="Stretch"/>
+        <Child type="Widget" skin="PU_BL" offset="0 17 2 2" align="Stretch"/>
     </Skin>
-    <Skin name = "PinDown" size = "19 19" texture="textures\menu_rightbuttondown_center.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 19 19">
-            <State name="normal" offset = "0 0 19 19"/>
+    <Skin name="PinDown" size="19 19" texture="textures\menu_rightbuttondown_center.dds">
+        <BasisSkin type="MainSkin" offset="0 0 19 19">
+            <State name="normal" offset="0 0 19 19"/>
         </BasisSkin>
-        <Child type="Widget" skin="PD_B"  offset="2 17 15 2" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PD_BR" offset="17 17 2 2" align="HStretch VStretch"/>
-				<Child type="Widget" skin="PD_R"  offset="17 2 2 15" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PD_TR" offset="17 0 2 2" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PD_T"  offset="2 0 15 2" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PD_TL" offset="0 0 2 2" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PD_L"  offset="0 2 2 15" align="HStretch VStretch"/>
-        <Child type="Widget" skin="PD_BL" offset="0 17 2 2" align="HStretch VStretch"/>
+        <Child type="Widget" skin="PD_B"  offset="2 17 15 2" align="Stretch"/>
+        <Child type="Widget" skin="PD_BR" offset="17 17 2 2" align="Stretch"/>
+				<Child type="Widget" skin="PD_R"  offset="17 2 2 15" align="Stretch"/>
+        <Child type="Widget" skin="PD_TR" offset="17 0 2 2" align="Stretch"/>
+        <Child type="Widget" skin="PD_T"  offset="2 0 15 2" align="Stretch"/>
+        <Child type="Widget" skin="PD_TL" offset="0 0 2 2" align="Stretch"/>
+        <Child type="Widget" skin="PD_L"  offset="0 2 2 15" align="Stretch"/>
+        <Child type="Widget" skin="PD_BL" offset="0 17 2 2" align="Stretch"/>
     </Skin>
 
     <!-- Defines a pure black background -->
-    <Skin name = "DialogBG" size = "8 8" texture = "black.png">
-        <BasisSkin type="MainSkin" offset = "0 0 8 8">
-            <State name="normal" offset = "0 0 8 8"/>
+    <Skin name="DialogBG" size="8 8" texture="black.png">
+        <BasisSkin type="MainSkin" offset="0 0 8 8">
+            <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>
     </Skin>
 
@@ -149,43 +149,43 @@
     </Skin>
 
     <Skin name="DB_T" size="512 4" texture="textures\menu_thick_border_top.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 512 4">
-            <State name="normal" offset = "0 0 512 4"/>
+        <BasisSkin type="MainSkin" offset="0 0 512 4">
+            <State name="normal" offset="0 0 512 4"/>
         </BasisSkin>
     </Skin>
 
     <Skin name="DB_L" size="4 512" texture="textures\menu_thick_border_left.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 4 512">
-            <State name="normal" offset = "0 0 4 512"/>
+        <BasisSkin type="MainSkin" offset="0 0 4 512">
+            <State name="normal" offset="0 0 4 512"/>
         </BasisSkin>
     </Skin>
 
     <!-- Dialog border corners -->
     <Skin name="DB_BR" size="4 4" texture="textures\menu_thick_border_bottom_right_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="DB_BL" size="4 4" texture="textures\menu_thick_border_bottom_left_corner.dds">
-        <Property key="Pointer" value = "dresize2" />
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <Property key="Pointer" value="dresize2" />
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="DB_TR" size="4 4" texture="textures\menu_thick_border_top_right_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="DB_TL" size="4 4" texture="textures\menu_thick_border_top_left_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
 
     <!-- These define the window borders -->
     <Skin name="TB_B" size="512 4" texture="textures\menu_thick_border_bottom.dds">
-        <Property key="Pointer" value = "vresize" />
+        <Property key="Pointer" value="vresize" />
         <BasisSkin type="TileRect" offset="0 0 512 4" align="Stretch">
             <State name="normal" offset="0 0 512 4">
                 <Property key="TileSize" value="512 4"/>
@@ -196,7 +196,7 @@
     </Skin>
 
     <Skin name="TB_R" size="4 512" texture="textures\menu_thick_border_right.dds">
-        <Property key="Pointer" value = "hresize" />
+        <Property key="Pointer" value="hresize" />
         <BasisSkin type="TileRect" offset="0 0 4 512" align="Stretch">
             <State name="normal" offset="0 0 4 512">
                 <Property key="TileSize" value="4 512"/>
@@ -207,7 +207,7 @@
     </Skin>
 
     <Skin name="TB_T" size="512 4" texture="textures\menu_thick_border_top.dds">
-        <Property key="Pointer" value = "vresize" />
+        <Property key="Pointer" value="vresize" />
         <BasisSkin type="TileRect" offset="0 0 512 4" align="Stretch">
             <State name="normal" offset="0 0 512 4">
                 <Property key="TileSize" value="512 4"/>
@@ -218,7 +218,7 @@
     </Skin>
 
     <Skin name="TB_L" size="4 512" texture="textures\menu_thick_border_left.dds">
-        <Property key="Pointer" value = "hresize" />
+        <Property key="Pointer" value="hresize" />
         <BasisSkin type="TileRect" offset="0 0 4 512" align="Stretch">
             <State name="normal" offset="0 0 4 512">
                 <Property key="TileSize" value="4 512"/>
@@ -230,27 +230,27 @@
 
     <!-- Window border corners -->
     <Skin name="TB_BR" size="4 4" texture="textures\menu_thick_border_bottom_right_corner.dds">
-        <Property key="Pointer" value = "dresize" />
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <Property key="Pointer" value="dresize" />
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="TB_BL" size="4 4" texture="textures\menu_thick_border_bottom_left_corner.dds">
-        <Property key="Pointer" value = "dresize2" />
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <Property key="Pointer" value="dresize2" />
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="TB_TR" size="4 4" texture="textures\menu_thick_border_top_right_corner.dds">
-        <Property key="Pointer" value = "dresize2" />
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <Property key="Pointer" value="dresize2" />
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
     <Skin name="TB_TL" size="4 4" texture="textures\menu_thick_border_top_left_corner.dds">
-        <Property key="Pointer" value = "dresize" />
-        <BasisSkin type="MainSkin" offset = "0 0 4 4">
-            <State name="normal" offset = "0 0 4 4"/>
+        <Property key="Pointer" value="dresize" />
+        <BasisSkin type="MainSkin" offset="0 0 4 4">
+            <State name="normal" offset="0 0 4 4"/>
         </BasisSkin>
     </Skin>
 
@@ -286,35 +286,35 @@
     </Skin>
 
     <Skin name="HB_LEFT" size="2 16" texture="textures\menu_head_block_left.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 16">
-            <State name="normal" offset = "0 0 2 16"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 16">
+            <State name="normal" offset="0 0 2 16"/>
         </BasisSkin>
     </Skin>
 
     <Skin name="HB_RIGHT" size="2 16" texture="textures\menu_head_block_right.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 16">
-            <State name="normal" offset = "0 0 2 16"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 16">
+            <State name="normal" offset="0 0 2 16"/>
         </BasisSkin>
     </Skin>
 
     <Skin name="HB_TR" size="2 2" texture="textures\menu_head_block_top_right_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="HB_TL" size="2 2" texture="textures\menu_head_block_top_left_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="HB_BR" size="2 2" texture="textures\menu_head_block_bottom_right_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
     <Skin name="HB_BL" size="2 2" texture="textures\menu_head_block_bottom_left_corner.dds">
-        <BasisSkin type="MainSkin" offset = "0 0 2 2">
-            <State name="normal" offset = "0 0 2 2"/>
+        <BasisSkin type="MainSkin" offset="0 0 2 2">
+            <State name="normal" offset="0 0 2 2"/>
         </BasisSkin>
     </Skin>
 
@@ -332,15 +332,15 @@
 
     <!-- The actual caption. It contains the edges of the blocks on
          its sides as well -->
-    <Skin name = "MW_Caption" size = "88 20" texture = "black.png" >
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Center" />
-        <Property key="TextColour" value = "0.75 0.62 0.36" />
+    <Skin name="MW_Caption" size="88 20" texture="black.png" >
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Center" />
+        <Property key="TextColour" value="0.75 0.62 0.36" />
 
         <BasisSkin type="SubSkin" offset="0 0 88 20" align="Stretch">
-            <State name="normal" offset = "0 0 8 8"/>
+            <State name="normal" offset="0 0 8 8"/>
         </BasisSkin>
-        <BasisSkin type="SimpleText" offset = "2 0 84 20" align = "Stretch"/>
+        <BasisSkin type="SimpleText" offset="2 0 84 20" align="Stretch"/>
 
         <!-- Add the borders of the surrounding blocks -->
         <Child type="Widget" skin="HB_LEFT" offset="86 2 2 16" align="Top Right"/>
@@ -357,269 +357,269 @@
 
 ------------------------------------------------------ -->
 
-    <Skin name = "MW_Window" size = "256 54">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Center" />
-        <Property key="TextColour" value = "0.8 0.8 0.8" />
-        <Property key="Snap" value = "true" />
+    <Skin name="MW_Window" size="256 54">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Center" />
+        <Property key="TextColour" value="0.8 0.8 0.8" />
+        <Property key="Snap" value="true" />
         <Property key="MinSize" value="64 64"/>
 
-        <Child type="Widget" skin="BlackBG" offset = "8 28 240 18" align = "Stretch" name = "Client"/>
+        <Child type="Widget" skin="BlackBG" offset="8 28 240 18" align="Stretch" name="Client"/>
 
         <!-- Outer borders -->
         <Child type="Widget" skin="TB_T" offset="4 0 248 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value = "0 1 0 -1"/>
+            <Property key="Scale" value="0 1 0 -1"/>
         </Child>
         <Child type="Widget" skin="TB_L" offset="0 4 4 46" align="Left VStretch" name="Action">
-            <Property key="Scale" value = "1 0 -1 0"/>
+            <Property key="Scale" value="1 0 -1 0"/>
         </Child>
         <Child type="Widget" skin="TB_B" offset="4 50 248 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value = "0 0 0 1"/>
+            <Property key="Scale" value="0 0 0 1"/>
         </Child>
         <Child type="Widget" skin="TB_R" offset="252 4 4 46" align="Right VStretch" name="Action">
-            <Property key="Scale" value = "0 0 1 0"/>
+            <Property key="Scale" value="0 0 1 0"/>
         </Child>
 
         <Child type="Widget" skin="TB_BR" offset="252 50 4 4" align="Right Bottom" name="Action">
-            <Property key="Scale" value = "0 0 1 1"/>
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
         <Child type="Widget" skin="TB_BL" offset="0 50 4 4" align="Left Bottom" name="Action">
-            <Property key="Scale" value = "1 0 -1 1"/>
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
-            <Property key="Scale" value = "0 1 1 -1"/>
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="0 0 4 4" align="Left Top" name="Action">
-            <Property key="Scale" value = "1 1 -1 -1"/>
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
 
         <!-- Inner borders -->
         <Child type="Widget" skin="TB_T" offset="8 24 240 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value = "0 1 0 -1"/>
+            <Property key="Scale" value="0 1 0 -1"/>
         </Child>
         <Child type="Widget" skin="TB_L" offset="4 28 4 18" align="Left VStretch" name="Action">
-            <Property key="Scale" value = "1 0 -1 0"/>
+            <Property key="Scale" value="1 0 -1 0"/>
         </Child>
         <Child type="Widget" skin="TB_B" offset="8 46 240 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value = "0 0 0 1"/>
+            <Property key="Scale" value="0 0 0 1"/>
         </Child>
         <Child type="Widget" skin="TB_R" offset="248 28 4 18" align="Right VStretch" name="Action">
-            <Property key="Scale" value = "0 0 1 0"/>
+            <Property key="Scale" value="0 0 1 0"/>
         </Child>
         <Child type="Widget" skin="TB_BR" offset="248 46 4 4" align="Bottom Right" name="Action">
-            <Property key="Scale" value = "0 0 1 1"/>
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
         <Child type="Widget" skin="TB_BL" offset="4 46 4 4" align="Bottom Left" name="Action">
-            <Property key="Scale" value = "1 0 -1 1"/>
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="248 24 4 4" align="Top Right" name="Action">
-            <Property key="Scale" value = "0 1 1 -1"/>
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
-            <Property key="Scale" value = "1 1 -1 -1"/>
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
 
         <!-- Caption -->
-        <Child type="Widget" skin="HB_ALL" offset="4 4 248 20" align = "Top HStretch">
-            <Property key="Scale" value = "1 1 0 0"/>
+        <Child type="Widget" skin="HB_ALL" offset="4 4 248 20" align="Top HStretch">
+            <Property key="Scale" value="1 1 0 0"/>
         </Child>
 
-        <Child type="TextBox" skin="MW_Caption" offset = "80 4 88 20" align = "HCenter Top" name = "Caption">
+        <Child type="TextBox" skin="MW_Caption" offset="80 4 88 20" align="HCenter Top" name="Caption">
         </Child>
 
         <!-- This invisible button makes it possible to move the
              window by dragging the caption. -->
         <Child type="Button" offset="4 4 248 20" align="HStretch Top" name="Action">
-            <Property key="Scale" value = "1 1 0 0"/>
+            <Property key="Scale" value="1 1 0 0"/>
         </Child>
     </Skin>
 
-    <Skin name = "MW_Window_NoCaption" size = "256 54">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Center" />
-        <Property key="TextColour" value = "0.8 0.8 0.8" />
-        <Property key="Snap" value = "true" />
+    <Skin name="MW_Window_NoCaption" size="256 54">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Center" />
+        <Property key="TextColour" value="0.8 0.8 0.8" />
+        <Property key="Snap" value="true" />
         <Property key="MinSize" value="64 64"/>
 
-        <Child type="Widget" skin="BlackBG" offset = "8 28 240 18" align = "Stretch" name = "Client"/>
+        <Child type="Widget" skin="BlackBG" offset="8 28 240 18" align="Stretch" name="Client"/>
 
         <!-- Outer borders -->
         <Child type="Widget" skin="TB_T" offset="4 0 248 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value = "0 1 0 -1"/>
+            <Property key="Scale" value="0 1 0 -1"/>
         </Child>
         <Child type="Widget" skin="TB_L" offset="0 4 4 46" align="Left VStretch" name="Action">
-            <Property key="Scale" value = "1 0 -1 0"/>
+            <Property key="Scale" value="1 0 -1 0"/>
         </Child>
         <Child type="Widget" skin="TB_B" offset="4 50 248 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value = "0 0 0 1"/>
+            <Property key="Scale" value="0 0 0 1"/>
         </Child>
         <Child type="Widget" skin="TB_R" offset="252 4 4 46" align="Right VStretch" name="Action">
-            <Property key="Scale" value = "0 0 1 0"/>
+            <Property key="Scale" value="0 0 1 0"/>
         </Child>
 
         <Child type="Widget" skin="TB_BR" offset="252 50 4 4" align="Right Bottom" name="Action">
-            <Property key="Scale" value = "0 0 1 1"/>
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
         <Child type="Widget" skin="TB_BL" offset="0 50 4 4" align="Left Bottom" name="Action">
-            <Property key="Scale" value = "1 0 -1 1"/>
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
-            <Property key="Scale" value = "0 1 1 -1"/>
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="0 0 4 4" align="Left Top" name="Action">
-            <Property key="Scale" value = "1 1 -1 -1"/>
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
 
         <!-- Inner borders -->
         <Child type="Widget" skin="TB_T" offset="8 24 240 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value = "0 1 0 -1"/>
+            <Property key="Scale" value="0 1 0 -1"/>
         </Child>
         <Child type="Widget" skin="TB_L" offset="4 28 4 18" align="Left VStretch" name="Action">
-            <Property key="Scale" value = "1 0 -1 0"/>
+            <Property key="Scale" value="1 0 -1 0"/>
         </Child>
         <Child type="Widget" skin="TB_B" offset="8 46 240 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value = "0 0 0 1"/>
+            <Property key="Scale" value="0 0 0 1"/>
         </Child>
         <Child type="Widget" skin="TB_R" offset="248 28 4 18" align="Right VStretch" name="Action">
-            <Property key="Scale" value = "0 0 1 0"/>
+            <Property key="Scale" value="0 0 1 0"/>
         </Child>
         <Child type="Widget" skin="TB_BR" offset="248 46 4 4" align="Bottom Right" name="Action">
-            <Property key="Scale" value = "0 0 1 1"/>
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
         <Child type="Widget" skin="TB_BL" offset="4 46 4 4" align="Bottom Left" name="Action">
-            <Property key="Scale" value = "1 0 -1 1"/>
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="248 24 4 4" align="Top Right" name="Action">
-            <Property key="Scale" value = "0 1 1 -1"/>
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
-            <Property key="Scale" value = "1 1 -1 -1"/>
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
 
         <!-- Caption -->
-        <Child type="Widget" skin="HB_ALL" offset="4 4 248 20" align = "Top HStretch">
-            <Property key="Scale" value = "1 1 0 0"/>
+        <Child type="Widget" skin="HB_ALL" offset="4 4 248 20" align="Top HStretch">
+            <Property key="Scale" value="1 1 0 0"/>
         </Child>
 
         <!-- This invisible button makes it possible to move the
              window by dragging the caption. -->
         <Child type="Button" offset="4 4 248 20" align="HStretch Top" name="Action">
-            <Property key="Scale" value = "1 1 0 0"/>
+            <Property key="Scale" value="1 1 0 0"/>
         </Child>
     </Skin>
 
-    <Skin name = "MW_Window_Pinnable" size = "256 54">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Center" />
-        <Property key="TextColour" value = "0.8 0.8 0.8" />
-        <Property key="Snap" value = "true" />
+    <Skin name="MW_Window_Pinnable" size="256 54">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Center" />
+        <Property key="TextColour" value="0.8 0.8 0.8" />
+        <Property key="Snap" value="true" />
         <Property key="MinSize" value="64 64"/>
 
-        <Child type="Widget" skin="BlackBG" offset = "8 28 240 18" align = "Stretch" name = "Client"/>
+        <Child type="Widget" skin="BlackBG" offset="8 28 240 18" align="Stretch" name="Client"/>
 
         <!-- Outer borders -->
         <Child type="Widget" skin="TB_T" offset="4 0 248 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value = "0 1 0 -1"/>
+            <Property key="Scale" value="0 1 0 -1"/>
         </Child>
         <Child type="Widget" skin="TB_L" offset="0 4 4 46" align="Left VStretch" name="Action">
-            <Property key="Scale" value = "1 0 -1 0"/>
+            <Property key="Scale" value="1 0 -1 0"/>
         </Child>
         <Child type="Widget" skin="TB_B" offset="4 50 248 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value = "0 0 0 1"/>
+            <Property key="Scale" value="0 0 0 1"/>
         </Child>
         <Child type="Widget" skin="TB_R" offset="252 4 4 46" align="Right VStretch" name="Action">
-            <Property key="Scale" value = "0 0 1 0"/>
+            <Property key="Scale" value="0 0 1 0"/>
         </Child>
 
         <Child type="Widget" skin="TB_BR" offset="252 50 4 4" align="Right Bottom" name="Action">
-            <Property key="Scale" value = "0 0 1 1"/>
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
         <Child type="Widget" skin="TB_BL" offset="0 50 4 4" align="Left Bottom" name="Action">
-            <Property key="Scale" value = "1 0 -1 1"/>
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
-            <Property key="Scale" value = "0 1 1 -1"/>
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="0 0 4 4" align="Left Top" name="Action">
-            <Property key="Scale" value = "1 1 -1 -1"/>
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
 
         <!-- Inner borders -->
         <Child type="Widget" skin="TB_T" offset="8 24 240 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value = "0 1 0 -1"/>
+            <Property key="Scale" value="0 1 0 -1"/>
         </Child>
         <Child type="Widget" skin="TB_L" offset="4 28 4 18" align="Left VStretch" name="Action">
-            <Property key="Scale" value = "1 0 -1 0"/>
+            <Property key="Scale" value="1 0 -1 0"/>
         </Child>
         <Child type="Widget" skin="TB_B" offset="8 46 240 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value = "0 0 0 1"/>
+            <Property key="Scale" value="0 0 0 1"/>
         </Child>
         <Child type="Widget" skin="TB_R" offset="248 28 4 18" align="Right VStretch" name="Action">
-            <Property key="Scale" value = "0 0 1 0"/>
+            <Property key="Scale" value="0 0 1 0"/>
         </Child>
         <Child type="Widget" skin="TB_BR" offset="248 46 4 4" align="Bottom Right" name="Action">
-            <Property key="Scale" value = "0 0 1 1"/>
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
         <Child type="Widget" skin="TB_BL" offset="4 46 4 4" align="Bottom Left" name="Action">
-            <Property key="Scale" value = "1 0 -1 1"/>
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="248 24 4 4" align="Top Right" name="Action">
-            <Property key="Scale" value = "0 1 1 -1"/>
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
-            <Property key="Scale" value = "1 1 -1 -1"/>
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
 
         <!-- Caption -->
 
-        <Child type="Widget" skin="HB_ALL" offset="4 4 248 20" align = "Top HStretch">
-            <Property key="Scale" value = "1 1 0 0"/>
+        <Child type="Widget" skin="HB_ALL" offset="4 4 248 20" align="Top HStretch">
+            <Property key="Scale" value="1 1 0 0"/>
         </Child>
 
-        <Child type="TextBox" skin="MW_Caption" offset = "80 4 88 20" align = "HCenter Top" name = "Caption">
+        <Child type="TextBox" skin="MW_Caption" offset="80 4 88 20" align="HCenter Top" name="Caption">
         </Child>
 
         <!-- This invisible button makes it possible to move the
              window by dragging the caption. -->
         <Child type="Button" offset="4 4 248 20" align="HStretch Top" name="Action">
-            <Property key="Scale" value = "1 1 0 0"/>
+            <Property key="Scale" value="1 1 0 0"/>
         </Child>
 
         <Child type="Button" skin="PinUp" offset="232 4 19 19" align="Right Top" name="Button"/>
     </Skin>
 
-    <Skin name = "MW_Dialog" size = "256 54">
-        <Property key="FontName" value = "Default" />
-        <Property key="TextAlign" value = "Center" />
-        <Property key="TextColour" value = "0.8 0.8 0.8" />
+    <Skin name="MW_Dialog" size="256 54">
+        <Property key="FontName" value="Default" />
+        <Property key="TextAlign" value="Center" />
+        <Property key="TextColour" value="0.8 0.8 0.8" />
 
-        <Child type="Widget" skin="BlackBG" offset = "4 4 248 46" align = "Stretch" name = "Client"/>
+        <Child type="Widget" skin="BlackBG" offset="4 4 248 46" align="Stretch" name="Client"/>
 
         <!-- Outer borders -->
         <Child type="Widget" skin="DB_T" offset="4 0 248 4" align="Top HStretch" name="Border">
-            <Property key="Scale" value = "0 1 0 -1"/>
+            <Property key="Scale" value="0 1 0 -1"/>
         </Child>
         <Child type="Widget" skin="DB_L" offset="0 4 4 46" align="Left VStretch" name="Border">
-            <Property key="Scale" value = "1 0 -1 0"/>
+            <Property key="Scale" value="1 0 -1 0"/>
         </Child>
         <Child type="Widget" skin="DB_B" offset="4 50 248 4" align="Bottom HStretch" name="Border">
-            <Property key="Scale" value = "0 0 0 1"/>
+            <Property key="Scale" value="0 0 0 1"/>
         </Child>
         <Child type="Widget" skin="DB_R" offset="252 4 4 46" align="Right VStretch" name="Border">
-            <Property key="Scale" value = "0 0 1 0"/>
+            <Property key="Scale" value="0 0 1 0"/>
         </Child>
 
         <Child type="Widget" skin="DB_BR" offset="252 50 4 4" align="Right Bottom" name="Border">
-            <Property key="Scale" value = "0 0 1 1"/>
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
         <Child type="Widget" skin="DB_BL" offset="0 50 4 4" align="Left Bottom" name="Border">
-            <Property key="Scale" value = "1 0 -1 1"/>
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
         <Child type="Widget" skin="DB_TR" offset="252 0 4 4" align="Right Top" name="Border">
-            <Property key="Scale" value = "0 1 1 -1"/>
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="DB_TL" offset="0 0 4 4" align="Left Top" name="Border">
-            <Property key="Scale" value = "1 1 -1 -1"/>
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
     </Skin>
 </MyGUI>

--- a/files/mygui/openmw_windows.skin.xml
+++ b/files/mygui/openmw_windows.skin.xml
@@ -254,6 +254,63 @@
         </BasisSkin>
     </Skin>
 
+    <!-- Expanded border corners, to get larger diagonal corner pointer area -->
+    <Skin name="TB_TL_T" size="10 4" texture="textures\menu_thick_border_top.dds">
+        <Property key="Pointer" value="dresize" />
+        <BasisSkin type="MainSkin" offset="0 0 10 4">
+            <State name="normal" offset="0 0 10 4"/>
+        </BasisSkin>
+    </Skin>
+
+    <Skin name="TB_TL_B" size="4 10" texture="textures\menu_thick_border_left.dds">
+        <Property key="Pointer" value="dresize" />
+        <BasisSkin type="MainSkin" offset="0 0 4 10">
+            <State name="normal" offset="0 0 4 10"/>
+        </BasisSkin>
+    </Skin>
+
+    <Skin name="TB_TR_T" size="10 4" texture="textures\menu_thick_border_top.dds">
+        <Property key="Pointer" value="dresize2" />
+        <BasisSkin type="MainSkin" offset="0 0 10 4">
+            <State name="normal" offset="0 0 10 4"/>
+        </BasisSkin>
+    </Skin>
+
+    <Skin name="TB_TR_B" size="4 10" texture="textures\menu_thick_border_right.dds">
+        <Property key="Pointer" value="dresize2" />
+        <BasisSkin type="MainSkin" offset="0 0 4 10">
+            <State name="normal" offset="0 0 4 10"/>
+        </BasisSkin>
+    </Skin>
+
+    <Skin name="TB_BL_T" size="4 10" texture="textures\menu_thick_border_left.dds">
+        <Property key="Pointer" value="dresize2" />
+        <BasisSkin type="MainSkin" offset="0 0 4 10">
+            <State name="normal" offset="0 0 4 10"/>
+        </BasisSkin>
+    </Skin>
+
+    <Skin name="TB_BL_B" size="10 4" texture="textures\menu_thick_border_bottom.dds">
+        <Property key="Pointer" value="dresize2" />
+        <BasisSkin type="MainSkin" offset="0 0 10 4">
+            <State name="normal" offset="0 0 10 4"/>
+        </BasisSkin>
+    </Skin>
+
+    <Skin name="TB_BR_T" size="4 10" texture="textures\menu_thick_border_right.dds">
+        <Property key="Pointer" value="dresize" />
+        <BasisSkin type="MainSkin" offset="0 0 4 10">
+            <State name="normal" offset="0 0 4 10"/>
+        </BasisSkin>
+    </Skin>
+
+    <Skin name="TB_BR_B" size="10 4" texture="textures\menu_thick_border_bottom.dds">
+        <Property key="Pointer" value="dresize" />
+        <BasisSkin type="MainSkin" offset="0 0 10 4">
+            <State name="normal" offset="0 0 10 4"/>
+        </BasisSkin>
+    </Skin>
+
     <!-- These parts defines the 'blocks' to the left and right of the caption -->
     <Skin name="HB_MID" size="256 16" texture="textures\menu_head_block_middle.dds">
         <BasisSkin type="TileRect" offset="0 0 256 16" align="Stretch">
@@ -357,66 +414,129 @@
 
 ------------------------------------------------------ -->
 
-    <Skin name="MW_Window" size="256 54">
+    <Skin name="MW_Window" size="256 256">
         <Property key="FontName" value="Default" />
         <Property key="TextAlign" value="Center" />
         <Property key="TextColour" value="0.8 0.8 0.8" />
         <Property key="Snap" value="true" />
         <Property key="MinSize" value="64 64"/>
 
-        <Child type="Widget" skin="BlackBG" offset="8 28 240 18" align="Stretch" name="Client"/>
+        <Child type="Widget" skin="BlackBG" offset="8 28 240 220" align="Stretch" name="Client"/>
 
-        <!-- Outer borders -->
-        <Child type="Widget" skin="TB_T" offset="4 0 248 4" align="Top HStretch" name="Action">
+        <!-- Outer Borders -->
+        <Child type="Widget" skin="TB_T" offset="14 0 228 4" align="Top HStretch" name="Action">
             <Property key="Scale" value="0 1 0 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_L" offset="0 4 4 46" align="Left VStretch" name="Action">
+        <Child type="Widget" skin="TB_L" offset="0 14 4 228" align="Left VStretch" name="Action">
             <Property key="Scale" value="1 0 -1 0"/>
         </Child>
-        <Child type="Widget" skin="TB_B" offset="4 50 248 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value="0 0 0 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_R" offset="252 4 4 46" align="Right VStretch" name="Action">
+        <Child type="Widget" skin="TB_R" offset="252 14 4 228" align="Right VStretch" name="Action">
             <Property key="Scale" value="0 0 1 0"/>
         </Child>
+        <Child type="Widget" skin="TB_B" offset="14 252 228 4" align="Bottom HStretch" name="Action">
+            <Property key="Scale" value="0 0 0 1"/>
+        </Child>
 
-        <Child type="Widget" skin="TB_BR" offset="252 50 4 4" align="Right Bottom" name="Action">
-            <Property key="Scale" value="0 0 1 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_BL" offset="0 50 4 4" align="Left Bottom" name="Action">
-            <Property key="Scale" value="1 0 -1 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
-            <Property key="Scale" value="0 1 1 -1"/>
+        <!-- OB: Top Left -->
+        <Child type="Widget" skin="TB_TL_T" offset="4 0 10 4" align="Left Top" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="0 0 4 4" align="Left Top" name="Action">
             <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
+        <Child type="Widget" skin="TB_TL_B" offset="0 4 4 10" align="Left Top" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
 
-        <!-- Inner borders -->
-        <Child type="Widget" skin="TB_T" offset="8 24 240 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value="0 1 0 -1"/>
+        <!-- OB: Top Right -->
+        <Child type="Widget" skin="TB_TR_T" offset="242 0 10 4" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_L" offset="4 28 4 18" align="Left VStretch" name="Action">
-            <Property key="Scale" value="1 0 -1 0"/>
+        <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_B" offset="8 46 240 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value="0 0 0 1"/>
+        <Child type="Widget" skin="TB_TR_B" offset="252 4 4 10" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_R" offset="248 28 4 18" align="Right VStretch" name="Action">
-            <Property key="Scale" value="0 0 1 0"/>
+
+        <!-- OB: Bottom Left -->
+        <Child type="Widget" skin="TB_BL_T" offset="0 242 4 10" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
-        <Child type="Widget" skin="TB_BR" offset="248 46 4 4" align="Bottom Right" name="Action">
+        <Child type="Widget" skin="TB_BL" offset="0 252 4 4" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL_B" offset="4 252 10 4" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+
+        <!-- OB: Bottom Right -->
+        <Child type="Widget" skin="TB_BR_T" offset="252 242 4 10" align="Right Bottom" name="Action">
             <Property key="Scale" value="0 0 1 1"/>
         </Child>
-        <Child type="Widget" skin="TB_BL" offset="4 46 4 4" align="Bottom Left" name="Action">
-            <Property key="Scale" value="1 0 -1 1"/>
+        <Child type="Widget" skin="TB_BR" offset="252 252 4 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR_B" offset="242 252 10 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+
+        <!-- Inner Borders -->
+        <Child type="Widget" skin="TB_T" offset="18 24 220 4" align="Top HStretch" name="Action">
+            <Property key="Scale" value="0 1 0 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_L" offset="4 38 4 200" align="Left VStretch" name="Action">
+            <Property key="Scale" value="1 0 -1 0"/>
+        </Child>
+        <Child type="Widget" skin="TB_R" offset="248 38 4 200" align="Right VStretch" name="Action">
+            <Property key="Scale" value="0 0 1 0"/>
+        </Child>
+        <Child type="Widget" skin="TB_B" offset="18 248 220 4" align="Bottom HStretch" name="Action">
+            <Property key="Scale" value="0 0 0 1"/>
+        </Child>
+
+        <!-- IB: Top Left -->
+        <Child type="Widget" skin="TB_TL_T" offset="8 24 10 4" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_TL_B" offset="4 28 4 10" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+
+        <!-- IB: Top Right -->
+        <Child type="Widget" skin="TB_TR_T" offset="238 24 10 4" align="Top Right" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="248 24 4 4" align="Top Right" name="Action">
             <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
-            <Property key="Scale" value="1 1 -1 -1"/>
+        <Child type="Widget" skin="TB_TR_B" offset="248 28 4 10" align="Top Right" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
+        </Child>
+
+        <!-- IB: Bottom Left -->
+        <Child type="Widget" skin="TB_BL_T" offset="4 238 4 10" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL" offset="4 248 4 4" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL_B" offset="8 248 10 4" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+
+        <!-- IB: Bottom Right -->
+        <Child type="Widget" skin="TB_BR_T" offset="248 238 4 10" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR" offset="248 248 4 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR_B" offset="238 248 10 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
 
         <!-- Caption -->
@@ -434,66 +554,129 @@
         </Child>
     </Skin>
 
-    <Skin name="MW_Window_NoCaption" size="256 54">
+    <Skin name="MW_Window_NoCaption" size="256 256">
         <Property key="FontName" value="Default" />
         <Property key="TextAlign" value="Center" />
         <Property key="TextColour" value="0.8 0.8 0.8" />
         <Property key="Snap" value="true" />
         <Property key="MinSize" value="64 64"/>
 
-        <Child type="Widget" skin="BlackBG" offset="8 28 240 18" align="Stretch" name="Client"/>
+        <Child type="Widget" skin="BlackBG" offset="8 28 240 220" align="Stretch" name="Client"/>
 
-        <!-- Outer borders -->
-        <Child type="Widget" skin="TB_T" offset="4 0 248 4" align="Top HStretch" name="Action">
+        <!-- Outer Borders -->
+        <Child type="Widget" skin="TB_T" offset="14 0 228 4" align="Top HStretch" name="Action">
             <Property key="Scale" value="0 1 0 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_L" offset="0 4 4 46" align="Left VStretch" name="Action">
+        <Child type="Widget" skin="TB_L" offset="0 14 4 228" align="Left VStretch" name="Action">
             <Property key="Scale" value="1 0 -1 0"/>
         </Child>
-        <Child type="Widget" skin="TB_B" offset="4 50 248 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value="0 0 0 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_R" offset="252 4 4 46" align="Right VStretch" name="Action">
+        <Child type="Widget" skin="TB_R" offset="252 14 4 228" align="Right VStretch" name="Action">
             <Property key="Scale" value="0 0 1 0"/>
         </Child>
+        <Child type="Widget" skin="TB_B" offset="14 252 228 4" align="Bottom HStretch" name="Action">
+            <Property key="Scale" value="0 0 0 1"/>
+        </Child>
 
-        <Child type="Widget" skin="TB_BR" offset="252 50 4 4" align="Right Bottom" name="Action">
-            <Property key="Scale" value="0 0 1 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_BL" offset="0 50 4 4" align="Left Bottom" name="Action">
-            <Property key="Scale" value="1 0 -1 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
-            <Property key="Scale" value="0 1 1 -1"/>
+        <!-- OB: Top Left -->
+        <Child type="Widget" skin="TB_TL_T" offset="4 0 10 4" align="Left Top" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="0 0 4 4" align="Left Top" name="Action">
             <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
+        <Child type="Widget" skin="TB_TL_B" offset="0 4 4 10" align="Left Top" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
 
-        <!-- Inner borders -->
-        <Child type="Widget" skin="TB_T" offset="8 24 240 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value="0 1 0 -1"/>
+        <!-- OB: Top Right -->
+        <Child type="Widget" skin="TB_TR_T" offset="242 0 10 4" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_L" offset="4 28 4 18" align="Left VStretch" name="Action">
-            <Property key="Scale" value="1 0 -1 0"/>
+        <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_B" offset="8 46 240 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value="0 0 0 1"/>
+        <Child type="Widget" skin="TB_TR_B" offset="252 4 4 10" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_R" offset="248 28 4 18" align="Right VStretch" name="Action">
-            <Property key="Scale" value="0 0 1 0"/>
+
+        <!-- OB: Bottom Left -->
+        <Child type="Widget" skin="TB_BL_T" offset="0 242 4 10" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
-        <Child type="Widget" skin="TB_BR" offset="248 46 4 4" align="Bottom Right" name="Action">
+        <Child type="Widget" skin="TB_BL" offset="0 252 4 4" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL_B" offset="4 252 10 4" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+
+        <!-- OB: Bottom Right -->
+        <Child type="Widget" skin="TB_BR_T" offset="252 242 4 10" align="Right Bottom" name="Action">
             <Property key="Scale" value="0 0 1 1"/>
         </Child>
-        <Child type="Widget" skin="TB_BL" offset="4 46 4 4" align="Bottom Left" name="Action">
-            <Property key="Scale" value="1 0 -1 1"/>
+        <Child type="Widget" skin="TB_BR" offset="252 252 4 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR_B" offset="242 252 10 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+
+        <!-- Inner Borders -->
+        <Child type="Widget" skin="TB_T" offset="18 24 220 4" align="Top HStretch" name="Action">
+            <Property key="Scale" value="0 1 0 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_L" offset="4 38 4 200" align="Left VStretch" name="Action">
+            <Property key="Scale" value="1 0 -1 0"/>
+        </Child>
+        <Child type="Widget" skin="TB_R" offset="248 38 4 200" align="Right VStretch" name="Action">
+            <Property key="Scale" value="0 0 1 0"/>
+        </Child>
+        <Child type="Widget" skin="TB_B" offset="18 248 220 4" align="Bottom HStretch" name="Action">
+            <Property key="Scale" value="0 0 0 1"/>
+        </Child>
+
+        <!-- IB: Top Left -->
+        <Child type="Widget" skin="TB_TL_T" offset="8 24 10 4" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_TL_B" offset="4 28 4 10" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+
+        <!-- IB: Top Right -->
+        <Child type="Widget" skin="TB_TR_T" offset="238 24 10 4" align="Top Right" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="248 24 4 4" align="Top Right" name="Action">
             <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
-            <Property key="Scale" value="1 1 -1 -1"/>
+        <Child type="Widget" skin="TB_TR_B" offset="248 28 4 10" align="Top Right" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
+        </Child>
+
+        <!-- IB: Bottom Left -->
+        <Child type="Widget" skin="TB_BL_T" offset="4 238 4 10" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL" offset="4 248 4 4" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL_B" offset="8 248 10 4" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+
+        <!-- IB: Bottom Right -->
+        <Child type="Widget" skin="TB_BR_T" offset="248 238 4 10" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR" offset="248 248 4 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR_B" offset="238 248 10 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
 
         <!-- Caption -->
@@ -508,66 +691,129 @@
         </Child>
     </Skin>
 
-    <Skin name="MW_Window_Pinnable" size="256 54">
+    <Skin name="MW_Window_Pinnable" size="256 256">
         <Property key="FontName" value="Default" />
         <Property key="TextAlign" value="Center" />
         <Property key="TextColour" value="0.8 0.8 0.8" />
         <Property key="Snap" value="true" />
         <Property key="MinSize" value="64 64"/>
 
-        <Child type="Widget" skin="BlackBG" offset="8 28 240 18" align="Stretch" name="Client"/>
+        <Child type="Widget" skin="BlackBG" offset="8 28 240 220" align="Stretch" name="Client"/>
 
-        <!-- Outer borders -->
-        <Child type="Widget" skin="TB_T" offset="4 0 248 4" align="Top HStretch" name="Action">
+        <!-- Outer Borders -->
+        <Child type="Widget" skin="TB_T" offset="14 0 228 4" align="Top HStretch" name="Action">
             <Property key="Scale" value="0 1 0 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_L" offset="0 4 4 46" align="Left VStretch" name="Action">
+        <Child type="Widget" skin="TB_L" offset="0 14 4 228" align="Left VStretch" name="Action">
             <Property key="Scale" value="1 0 -1 0"/>
         </Child>
-        <Child type="Widget" skin="TB_B" offset="4 50 248 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value="0 0 0 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_R" offset="252 4 4 46" align="Right VStretch" name="Action">
+        <Child type="Widget" skin="TB_R" offset="252 14 4 228" align="Right VStretch" name="Action">
             <Property key="Scale" value="0 0 1 0"/>
         </Child>
+        <Child type="Widget" skin="TB_B" offset="14 252 228 4" align="Bottom HStretch" name="Action">
+            <Property key="Scale" value="0 0 0 1"/>
+        </Child>
 
-        <Child type="Widget" skin="TB_BR" offset="252 50 4 4" align="Right Bottom" name="Action">
-            <Property key="Scale" value="0 0 1 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_BL" offset="0 50 4 4" align="Left Bottom" name="Action">
-            <Property key="Scale" value="1 0 -1 1"/>
-        </Child>
-        <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
-            <Property key="Scale" value="0 1 1 -1"/>
+        <!-- OB: Top Left -->
+        <Child type="Widget" skin="TB_TL_T" offset="4 0 10 4" align="Left Top" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TL" offset="0 0 4 4" align="Left Top" name="Action">
             <Property key="Scale" value="1 1 -1 -1"/>
         </Child>
+        <Child type="Widget" skin="TB_TL_B" offset="0 4 4 10" align="Left Top" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
 
-        <!-- Inner borders -->
-        <Child type="Widget" skin="TB_T" offset="8 24 240 4" align="Top HStretch" name="Action">
-            <Property key="Scale" value="0 1 0 -1"/>
+        <!-- OB: Top Right -->
+        <Child type="Widget" skin="TB_TR_T" offset="242 0 10 4" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_L" offset="4 28 4 18" align="Left VStretch" name="Action">
-            <Property key="Scale" value="1 0 -1 0"/>
+        <Child type="Widget" skin="TB_TR" offset="252 0 4 4" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_B" offset="8 46 240 4" align="Bottom HStretch" name="Action">
-            <Property key="Scale" value="0 0 0 1"/>
+        <Child type="Widget" skin="TB_TR_B" offset="252 4 4 10" align="Right Top" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_R" offset="248 28 4 18" align="Right VStretch" name="Action">
-            <Property key="Scale" value="0 0 1 0"/>
+
+        <!-- OB: Bottom Left -->
+        <Child type="Widget" skin="TB_BL_T" offset="0 242 4 10" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
         </Child>
-        <Child type="Widget" skin="TB_BR" offset="248 46 4 4" align="Bottom Right" name="Action">
+        <Child type="Widget" skin="TB_BL" offset="0 252 4 4" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL_B" offset="4 252 10 4" align="Left Bottom" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+
+        <!-- OB: Bottom Right -->
+        <Child type="Widget" skin="TB_BR_T" offset="252 242 4 10" align="Right Bottom" name="Action">
             <Property key="Scale" value="0 0 1 1"/>
         </Child>
-        <Child type="Widget" skin="TB_BL" offset="4 46 4 4" align="Bottom Left" name="Action">
-            <Property key="Scale" value="1 0 -1 1"/>
+        <Child type="Widget" skin="TB_BR" offset="252 252 4 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR_B" offset="242 252 10 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+
+        <!-- Inner Borders -->
+        <Child type="Widget" skin="TB_T" offset="18 24 220 4" align="Top HStretch" name="Action">
+            <Property key="Scale" value="0 1 0 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_L" offset="4 38 4 200" align="Left VStretch" name="Action">
+            <Property key="Scale" value="1 0 -1 0"/>
+        </Child>
+        <Child type="Widget" skin="TB_R" offset="248 38 4 200" align="Right VStretch" name="Action">
+            <Property key="Scale" value="0 0 1 0"/>
+        </Child>
+        <Child type="Widget" skin="TB_B" offset="18 248 220 4" align="Bottom HStretch" name="Action">
+            <Property key="Scale" value="0 0 0 1"/>
+        </Child>
+
+        <!-- IB: Top Left -->
+        <Child type="Widget" skin="TB_TL_T" offset="8 24 10 4" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+        <Child type="Widget" skin="TB_TL_B" offset="4 28 4 10" align="Top Left" name="Action">
+            <Property key="Scale" value="1 1 -1 -1"/>
+        </Child>
+
+        <!-- IB: Top Right -->
+        <Child type="Widget" skin="TB_TR_T" offset="238 24 10 4" align="Top Right" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
         </Child>
         <Child type="Widget" skin="TB_TR" offset="248 24 4 4" align="Top Right" name="Action">
             <Property key="Scale" value="0 1 1 -1"/>
         </Child>
-        <Child type="Widget" skin="TB_TL" offset="4 24 4 4" align="Top Left" name="Action">
-            <Property key="Scale" value="1 1 -1 -1"/>
+        <Child type="Widget" skin="TB_TR_B" offset="248 28 4 10" align="Top Right" name="Action">
+            <Property key="Scale" value="0 1 1 -1"/>
+        </Child>
+
+        <!-- IB: Bottom Left -->
+        <Child type="Widget" skin="TB_BL_T" offset="4 238 4 10" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL" offset="4 248 4 4" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BL_B" offset="8 248 10 4" align="Bottom Left" name="Action">
+            <Property key="Scale" value="1 0 -1 1"/>
+        </Child>
+
+        <!-- IB: Bottom Right -->
+        <Child type="Widget" skin="TB_BR_T" offset="248 238 4 10" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR" offset="248 248 4 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
+        </Child>
+        <Child type="Widget" skin="TB_BR_B" offset="238 248 10 4" align="Right Bottom" name="Action">
+            <Property key="Scale" value="0 0 1 1"/>
         </Child>
 
         <!-- Caption -->


### PR DESCRIPTION
- Made the alchemy window resizable, so you can resize it if you are unable to see full description of created effects.
- Standardized some remaining align variations and use of spaces in code.
- Set a minimum width on all resizable windows, so they don't look awful if resized too small.
- Layoutfixes for the settings window.
- Layoutfixes for the console window.
- Expanded the area in resizable windows, where the diagonal cursor would show to 14px x 14px instead of 4px x 4px.
