### PR TITLE
Ptr improvements

### DIFF
--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -389,7 +389,7 @@ namespace MWGui
 
                 // Unset OnPCEquip Variable on item's script, if it has a script with that variable declared
                 if(script != "")
-                    (*it).mRefData->getLocals().setVarByInt(script, "onpcequip", 0);
+                    (*it).getRefData().getLocals().setVarByInt(script, "onpcequip", 0);
 
                 return;
             }

--- a/apps/openmw/mwgui/tradeitemmodel.cpp
+++ b/apps/openmw/mwgui/tradeitemmodel.cpp
@@ -146,27 +146,30 @@ namespace MWGui
         for (size_t i=0; i<mSourceModel->getItemCount(); ++i)
         {
             ItemStack item = mSourceModel->getItem(i);
-            MWWorld::Ptr base = item.mBase;
-            if (!mMerchant.isEmpty() && Misc::StringUtils::ciEqual(base.getCellRef().mRefID, "gold_001"))
-                continue;
-            if (!mMerchant.isEmpty() && !MWWorld::Class::get(base).canSell(base, services))
-                continue;
-
-            // don't show equipped items
-            if (mMerchant.getTypeName() == typeid(ESM::NPC).name())
+            if(!mMerchant.isEmpty())
             {
-                bool isEquipped = false;
-                MWWorld::InventoryStore& store = MWWorld::Class::get(mMerchant).getInventoryStore(mMerchant);
-                for (int slot=0; slot<MWWorld::InventoryStore::Slots; ++slot)
-                {
-                    MWWorld::ContainerStoreIterator equipped = store.getSlot(slot);
-                    if (equipped == store.end())
-                        continue;
-                    if (*equipped == base)
-                        isEquipped = true;
-                }
-                if (isEquipped)
+                MWWorld::Ptr base = item.mBase;
+                if(Misc::StringUtils::ciEqual(base.getCellRef().mRefID, "gold_001"))
                     continue;
+                if(!MWWorld::Class::get(base).canSell(base, services))
+                    continue;
+
+                // don't show equipped items
+                if(mMerchant.getTypeName() == typeid(ESM::NPC).name())
+                {
+                    bool isEquipped = false;
+                    MWWorld::InventoryStore& store = MWWorld::Class::get(mMerchant).getInventoryStore(mMerchant);
+                    for (int slot=0; slot<MWWorld::InventoryStore::Slots; ++slot)
+                    {
+                        MWWorld::ContainerStoreIterator equipped = store.getSlot(slot);
+                        if (equipped == store.end())
+                            continue;
+                        if (*equipped == base)
+                            isEquipped = true;
+                    }
+                    if (isEquipped)
+                        continue;
+                }
             }
 
             // don't show items that we borrowed to someone else

--- a/apps/openmw/mwworld/actionequip.cpp
+++ b/apps/openmw/mwworld/actionequip.cpp
@@ -82,6 +82,6 @@ namespace MWWorld
         
         /* Set OnPCEquip Variable on item's script, if the player is equipping it, and it has a script with that variable declared */
         if(equipped && actor == MWBase::Environment::get().getWorld()->getPlayer().getPlayer() && script != "")
-            (object).mRefData->getLocals().setVarByInt(script, "onpcequip", 1);
+            object.getRefData().getLocals().setVarByInt(script, "onpcequip", 1);
     }
 }

--- a/apps/openmw/mwworld/class.cpp
+++ b/apps/openmw/mwworld/class.cpp
@@ -245,9 +245,10 @@ namespace MWWorld
         throw std::runtime_error ("class does not support persistence");
     }
 
-    void Class::registerClass (const std::string& key,  boost::shared_ptr<Class> instance)
+    void Class::registerClass(const std::string& key,  boost::shared_ptr<Class> instance)
     {
-        sClasses.insert (std::make_pair (key, instance));
+        instance->mTypeName = key;
+        sClasses.insert(std::make_pair(key, instance));
     }
 
     std::string Class::getUpSoundId (const Ptr& ptr) const

--- a/apps/openmw/mwworld/class.hpp
+++ b/apps/openmw/mwworld/class.hpp
@@ -50,6 +50,8 @@ namespace MWWorld
     {
             static std::map<std::string, boost::shared_ptr<Class> > sClasses;
 
+            std::string mTypeName;
+
             // not implemented
             Class (const Class&);
             Class& operator= (const Class&);
@@ -72,6 +74,10 @@ namespace MWWorld
             };
 
             virtual ~Class();
+
+            const std::string& getTypeName() const {
+                return mTypeName;
+            }
 
             virtual std::string getId (const Ptr& ptr) const;
             ///< Return ID of \a ptr or throw an exception, if class does not support ID retrieval
@@ -292,7 +298,7 @@ namespace MWWorld
 
             static const Class& get (const Ptr& ptr)
             {
-                return get(ptr.getTypeName());
+                return ptr.getClass();
             }
             ///< If there is no class for this pointer, an exception is thrown.
 

--- a/apps/openmw/mwworld/class.hpp
+++ b/apps/openmw/mwworld/class.hpp
@@ -7,7 +7,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include "action.hpp"
+#include "ptr.hpp"
 
 namespace Ogre
 {
@@ -43,6 +43,7 @@ namespace MWWorld
     class InventoryStore;
     class PhysicsSystem;
     class CellStore;
+    class Action;
 
     /// \brief Base class for referenceable esm records
     class Class
@@ -227,17 +228,6 @@ namespace MWWorld
             ///
             /// (default implementation: return false)
 
-            static const Class& get (const std::string& key);
-            ///< If there is no class for this \a key, an exception is thrown.
-
-            static const Class& get (const Ptr& ptr)
-            {
-                return get (ptr.getTypeName());
-            }
-            ///< If there is no class for this pointer, an exception is thrown.
-
-            static void registerClass (const std::string& key,  boost::shared_ptr<Class> instance);
-
             virtual std::string getUpSoundId (const Ptr& ptr) const;
             ///< Return the up sound ID of \a ptr or throw an exception, if class does not support ID retrieval
             /// (default implementation: throw an exception)
@@ -296,6 +286,17 @@ namespace MWWorld
             virtual bool isNpc() const {
                 return false;
             }
+
+            static const Class& get (const std::string& key);
+            ///< If there is no class for this \a key, an exception is thrown.
+
+            static const Class& get (const Ptr& ptr)
+            {
+                return get(ptr.getTypeName());
+            }
+            ///< If there is no class for this pointer, an exception is thrown.
+
+            static void registerClass (const std::string& key,  boost::shared_ptr<Class> instance);
     };
 }
 

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -59,16 +59,16 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::end()
 bool MWWorld::ContainerStore::stacks(const Ptr& ptr1, const Ptr& ptr2)
 {
     /// \todo add current enchantment charge here when it is implemented
-    if (  ptr1.mCellRef->mRefID == ptr2.mCellRef->mRefID
+    if (  ptr1.getCellRef().mRefID == ptr2.getCellRef().mRefID
           && MWWorld::Class::get(ptr1).getScript(ptr1) == "" // item with a script never stacks
           && MWWorld::Class::get(ptr1).getEnchantment(ptr1) == "" // item with enchantment never stacks (we could revisit this later, but for now it makes selecting items in the spell window much easier)
-        && ptr1.mCellRef->mOwner == ptr2.mCellRef->mOwner
-        && ptr1.mCellRef->mSoul == ptr2.mCellRef->mSoul
+        && ptr1.getCellRef().mOwner == ptr2.getCellRef().mOwner
+        && ptr1.getCellRef().mSoul == ptr2.getCellRef().mSoul
           // item that is already partly used up never stacks
-          && (!MWWorld::Class::get(ptr1).hasItemHealth(ptr1) || ptr1.mCellRef->mCharge == -1
-              || MWWorld::Class::get(ptr1).getItemMaxHealth(ptr1) == ptr1.mCellRef->mCharge)
-        && (!MWWorld::Class::get(ptr2).hasItemHealth(ptr2) || ptr2.mCellRef->mCharge == -1
-            || MWWorld::Class::get(ptr2).getItemMaxHealth(ptr2) == ptr2.mCellRef->mCharge))
+          && (!MWWorld::Class::get(ptr1).hasItemHealth(ptr1) || ptr1.getCellRef().mCharge == -1
+              || MWWorld::Class::get(ptr1).getItemMaxHealth(ptr1) == ptr1.getCellRef().mCharge)
+        && (!MWWorld::Class::get(ptr2).hasItemHealth(ptr2) || ptr2.getCellRef().mCharge == -1
+            || MWWorld::Class::get(ptr2).getItemMaxHealth(ptr2) == ptr2.getCellRef().mCharge))
         return true;
 
     return false;
@@ -91,7 +91,7 @@ MWWorld::ContainerStoreIterator MWWorld::ContainerStore::add (const Ptr& itemPtr
             cell = 0; // Items in player's inventory have cell set to 0, so their scripts will never be removed
            
             // Set OnPCAdd special variable, if it is declared 
-            item.mRefData->getLocals().setVarByInt(script, "onpcadd", 1);
+            item.getRefData().getLocals().setVarByInt(script, "onpcadd", 1);
         }
         else
             cell = player.getCell();

--- a/apps/openmw/mwworld/inventorystore.cpp
+++ b/apps/openmw/mwworld/inventorystore.cpp
@@ -138,7 +138,7 @@ void MWWorld::InventoryStore::unequipAll(const MWWorld::Ptr& actor)
 
             // Unset OnPCEquip Variable on item's script, if it has a script with that variable declared
             if((actor.getRefData().getHandle() == "player") && (script != ""))
-                (*it).mRefData->getLocals().setVarByInt(script, "onpcequip", 0);
+                (*it).getRefData().getLocals().setVarByInt(script, "onpcequip", 0);
         }
     }
 }

--- a/apps/openmw/mwworld/livecellref.hpp
+++ b/apps/openmw/mwworld/livecellref.hpp
@@ -28,6 +28,8 @@ namespace MWWorld
         LiveCellRefBase(std::string type, const ESM::CellRef &cref=ESM::CellRef())
           : mTypeName(type), mRef(cref), mData(mRef)
         { }
+        /* Need this for the class to be recognized as polymorphic */
+        virtual ~LiveCellRefBase() { }
     };
 
     /// A reference to one object (of any type) in a cell.

--- a/apps/openmw/mwworld/livecellref.hpp
+++ b/apps/openmw/mwworld/livecellref.hpp
@@ -11,11 +11,12 @@ namespace MWWorld
 {
     class Ptr;
     class ESMStore;
+    class Class;
 
     /// Used to create pointers to hold any type of LiveCellRef<> object.
     struct LiveCellRefBase
     {
-        std::string mTypeName;
+        const Class *mClass;
 
         /** Information about this instance, such as 3D location and rotation
          * and individual type-dependent data.
@@ -25,9 +26,7 @@ namespace MWWorld
         /** runtime-data */
         RefData mData;
 
-        LiveCellRefBase(std::string type, const ESM::CellRef &cref=ESM::CellRef())
-          : mTypeName(type), mRef(cref), mData(mRef)
-        { }
+        LiveCellRefBase(std::string type, const ESM::CellRef &cref=ESM::CellRef());
         /* Need this for the class to be recognized as polymorphic */
         virtual ~LiveCellRefBase() { }
     };

--- a/apps/openmw/mwworld/livecellref.hpp
+++ b/apps/openmw/mwworld/livecellref.hpp
@@ -17,7 +17,16 @@ namespace MWWorld
     {
         std::string mTypeName;
 
-        LiveCellRefBase(std::string type) : mTypeName(type)
+        /** Information about this instance, such as 3D location and rotation
+         * and individual type-dependent data.
+         */
+        ESM::CellRef mRef;
+
+        /** runtime-data */
+        RefData mData;
+
+        LiveCellRefBase(std::string type, const ESM::CellRef &cref=ESM::CellRef())
+          : mTypeName(type), mRef(cref), mData(mRef)
         { }
     };
 
@@ -31,23 +40,15 @@ namespace MWWorld
     struct LiveCellRef : public LiveCellRefBase
     {
         LiveCellRef(const ESM::CellRef& cref, const X* b = NULL)
-            : LiveCellRefBase(typeid(X).name()), mBase(b), mRef(cref), mData(mRef)
+            : LiveCellRefBase(typeid(X).name(), cref), mBase(b)
         {}
 
         LiveCellRef(const X* b = NULL)
-            : LiveCellRefBase(typeid(X).name()), mBase(b), mData(mRef)
+            : LiveCellRefBase(typeid(X).name()), mBase(b)
         {}
 
         // The object that this instance is based on.
         const X* mBase;
-
-        /* Information about this instance, such as 3D location and
-            rotation and individual type-dependent data.
-        */
-        ESM::CellRef mRef;
-
-        /// runtime-data
-        RefData mData;
     };
 
 //    template<typename X> bool operator==(const LiveCellRef<X>& ref, int pRefnum);

--- a/apps/openmw/mwworld/livecellref.hpp
+++ b/apps/openmw/mwworld/livecellref.hpp
@@ -1,6 +1,8 @@
 #ifndef GAME_MWWORLD_LIVECELLREF_H
 #define GAME_MWWORLD_LIVECELLREF_H
 
+#include <typeinfo>
+
 #include <components/esm/cellref.hpp>
 
 #include "refdata.hpp"
@@ -10,6 +12,15 @@ namespace MWWorld
     class Ptr;
     class ESMStore;
 
+    /// Used to create pointers to hold any type of LiveCellRef<> object.
+    struct LiveCellRefBase
+    {
+        std::string mTypeName;
+
+        LiveCellRefBase(std::string type) : mTypeName(type)
+        { }
+    };
+
     /// A reference to one object (of any type) in a cell.
     ///
     /// Constructing this with a CellRef instance in the constructor means that
@@ -17,14 +28,14 @@ namespace MWWorld
     /// across to mData. If later adding data (such as position) to CellRef
     /// this would have to be manually copied across.
     template <typename X>
-    struct LiveCellRef
+    struct LiveCellRef : public LiveCellRefBase
     {
         LiveCellRef(const ESM::CellRef& cref, const X* b = NULL)
-            : mBase(b), mRef(cref), mData(mRef)
+            : LiveCellRefBase(typeid(X).name()), mBase(b), mRef(cref), mData(mRef)
         {}
 
         LiveCellRef(const X* b = NULL)
-            : mBase(b), mData(mRef)
+            : LiveCellRefBase(typeid(X).name()), mBase(b), mData(mRef)
         {}
 
         // The object that this instance is based on.

--- a/apps/openmw/mwworld/ptr.cpp
+++ b/apps/openmw/mwworld/ptr.cpp
@@ -5,7 +5,6 @@
 
 #include "containerstore.hpp"
 
-const std::string MWWorld::Ptr::sEmptyString;
 
 ESM::CellRef& MWWorld::Ptr::getCellRef() const
 {

--- a/apps/openmw/mwworld/ptr.cpp
+++ b/apps/openmw/mwworld/ptr.cpp
@@ -4,7 +4,22 @@
 #include <cassert>
 
 #include "containerstore.hpp"
+#include "class.hpp"
 
+
+/* This shouldn't really be here. */
+MWWorld::LiveCellRefBase::LiveCellRefBase(std::string type, const ESM::CellRef &cref)
+  : mClass(&Class::get(type)), mRef(cref), mData(mRef)
+{
+}
+
+
+const std::string& MWWorld::Ptr::getTypeName() const
+{
+    if(mRef != 0)
+        return mRef->mClass->getTypeName();
+    throw std::runtime_error("Can't get type name from an empty object.");
+}
 
 ESM::CellRef& MWWorld::Ptr::getCellRef() const
 {

--- a/apps/openmw/mwworld/ptr.cpp
+++ b/apps/openmw/mwworld/ptr.cpp
@@ -9,22 +9,22 @@ const std::string MWWorld::Ptr::sEmptyString;
 
 ESM::CellRef& MWWorld::Ptr::getCellRef() const
 {
-    assert (mCellRef);
+    assert(mRef);
 
     if (mContainerStore)
         mContainerStore->flagAsModified();
 
-    return *mCellRef;
+    return mRef->mRef;
 }
 
 MWWorld::RefData& MWWorld::Ptr::getRefData() const
 {
-    assert (mRefData);
+    assert(mRef);
 
     if (mContainerStore)
         mContainerStore->flagAsModified();
 
-    return *mRefData;
+    return mRef->mData;
 }
 
 void MWWorld::Ptr::setContainerStore (ContainerStore *store)

--- a/apps/openmw/mwworld/ptr.cpp
+++ b/apps/openmw/mwworld/ptr.cpp
@@ -5,6 +5,8 @@
 
 #include "containerstore.hpp"
 
+const std::string MWWorld::Ptr::sEmptyString;
+
 ESM::CellRef& MWWorld::Ptr::getCellRef() const
 {
     assert (mCellRef);

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -38,8 +38,7 @@ namespace MWWorld
                 return mPtr ? mPtr->mTypeName : sEmptyString;
             }
 
-            template<typename T>
-            Ptr (MWWorld::LiveCellRef<T> *liveCellRef, CellStore *cell)
+            Ptr (MWWorld::LiveCellRefBase *liveCellRef, CellStore *cell)
             : mContainerStore (0)
             {
                 mPtr = liveCellRef;

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -1,8 +1,6 @@
 #ifndef GAME_MWWORLD_PTR_H
 #define GAME_MWWORLD_PTR_H
 
-#include <boost/any.hpp>
-
 #include "cellstore.hpp"
 
 namespace MWWorld
@@ -18,7 +16,7 @@ namespace MWWorld
             typedef MWWorld::CellStore CellStore;
             ///< \deprecated
 
-            boost::any mPtr;
+            MWWorld::LiveCellRefBase *mPtr;
             ESM::CellRef *mCellRef;
             RefData *mRefData;
             CellStore *mCell;
@@ -27,17 +25,11 @@ namespace MWWorld
 
         public:
 
-            Ptr() : mCellRef (0), mRefData (0), mCell (0), mContainerStore (0) {}
+            Ptr() : mPtr (0), mCellRef (0), mRefData (0), mCell (0), mContainerStore (0) {}
 
             bool isEmpty() const
             {
-                return mPtr.empty();
-            }
-
-            const std::type_info& getType() const
-            {
-                assert (!mPtr.empty());
-                return mPtr.type();
+                return mPtr == 0;
             }
 
             const std::string& getTypeName() const
@@ -59,7 +51,15 @@ namespace MWWorld
             template<typename T>
             MWWorld::LiveCellRef<T> *get() const
             {
-                return boost::any_cast<MWWorld::LiveCellRef<T>*> (mPtr);
+                if(mPtr && mPtr->mTypeName == typeid(T).name())
+                    return static_cast<MWWorld::LiveCellRef<T>*>(mPtr);
+
+                std::stringstream str;
+                str<< "Bad LiveCellRef cast to "<<typeid(T).name()<<" from ";
+                if(mPtr != 0) str<< mPtr->mTypeName;
+                else str<< "an empty object";
+
+                throw std::runtime_error(str.str());
             }
 
             ESM::CellRef& getCellRef() const;

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -11,6 +11,8 @@ namespace MWWorld
 
     class Ptr
     {
+            static const std::string sEmptyString;
+
         public:
 
             typedef MWWorld::CellStore CellStore;
@@ -20,7 +22,6 @@ namespace MWWorld
             ESM::CellRef *mCellRef;
             RefData *mRefData;
             CellStore *mCell;
-            std::string mTypeName;
             ContainerStore *mContainerStore;
 
         public:
@@ -34,7 +35,7 @@ namespace MWWorld
 
             const std::string& getTypeName() const
             {
-                return mTypeName;
+                return mPtr ? mPtr->mTypeName : sEmptyString;
             }
 
             template<typename T>
@@ -45,7 +46,6 @@ namespace MWWorld
                 mCellRef = &liveCellRef->mRef;
                 mRefData = &liveCellRef->mData;
                 mCell = cell;
-                mTypeName = typeid (T).name();
             }
 
             template<typename T>

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -32,11 +32,13 @@ namespace MWWorld
                 return mRef == 0;
             }
 
-            const std::string& getTypeName() const
+            const std::string& getTypeName() const;
+
+            const Class& getClass() const
             {
                 if(mRef != 0)
-                    return mRef->mTypeName;
-                throw std::runtime_error("Can't get type name from an empty object.");
+                    return *(mRef->mClass);
+                throw std::runtime_error("Cannot get class of an empty object");
             }
 
             template<typename T>
@@ -47,7 +49,7 @@ namespace MWWorld
 
                 std::stringstream str;
                 str<< "Bad LiveCellRef cast to "<<typeid(T).name()<<" from ";
-                if(mRef != 0) str<< mRef->mTypeName;
+                if(mRef != 0) str<< getTypeName();
                 else str<< "an empty object";
 
                 throw std::runtime_error(str.str());

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -12,8 +12,6 @@ namespace MWWorld
 
     class Ptr
     {
-            static const std::string sEmptyString;
-
         public:
 
             typedef MWWorld::CellStore CellStore;
@@ -24,8 +22,10 @@ namespace MWWorld
             ContainerStore *mContainerStore;
 
         public:
-
-            Ptr() : mRef(0), mCell(0), mContainerStore(0) { }
+            Ptr(MWWorld::LiveCellRefBase *liveCellRef=0, CellStore *cell=0)
+              : mRef(liveCellRef), mCell(cell), mContainerStore(0)
+            {
+            }
 
             bool isEmpty() const
             {
@@ -34,14 +34,9 @@ namespace MWWorld
 
             const std::string& getTypeName() const
             {
-                return mRef ? mRef->mTypeName : sEmptyString;
-            }
-
-            Ptr (MWWorld::LiveCellRefBase *liveCellRef, CellStore *cell)
-            : mContainerStore (0)
-            {
-                mRef = liveCellRef;
-                mCell = cell;
+                if(mRef != 0)
+                    return mRef->mTypeName;
+                throw std::runtime_error("Can't get type name from an empty object.");
             }
 
             template<typename T>

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -18,44 +18,40 @@ namespace MWWorld
             typedef MWWorld::CellStore CellStore;
             ///< \deprecated
 
-            MWWorld::LiveCellRefBase *mPtr;
-            ESM::CellRef *mCellRef;
-            RefData *mRefData;
+            MWWorld::LiveCellRefBase *mRef;
             CellStore *mCell;
             ContainerStore *mContainerStore;
 
         public:
 
-            Ptr() : mPtr (0), mCellRef (0), mRefData (0), mCell (0), mContainerStore (0) {}
+            Ptr() : mRef(0), mCell(0), mContainerStore(0) { }
 
             bool isEmpty() const
             {
-                return mPtr == 0;
+                return mRef == 0;
             }
 
             const std::string& getTypeName() const
             {
-                return mPtr ? mPtr->mTypeName : sEmptyString;
+                return mRef ? mRef->mTypeName : sEmptyString;
             }
 
             Ptr (MWWorld::LiveCellRefBase *liveCellRef, CellStore *cell)
             : mContainerStore (0)
             {
-                mPtr = liveCellRef;
-                mCellRef = &liveCellRef->mRef;
-                mRefData = &liveCellRef->mData;
+                mRef = liveCellRef;
                 mCell = cell;
             }
 
             template<typename T>
             MWWorld::LiveCellRef<T> *get() const
             {
-                if(mPtr && mPtr->mTypeName == typeid(T).name())
-                    return static_cast<MWWorld::LiveCellRef<T>*>(mPtr);
+                if(mRef && mRef->mTypeName == typeid(T).name())
+                    return static_cast<MWWorld::LiveCellRef<T>*>(mRef);
 
                 std::stringstream str;
                 str<< "Bad LiveCellRef cast to "<<typeid(T).name()<<" from ";
-                if(mPtr != 0) str<< mPtr->mTypeName;
+                if(mRef != 0) str<< mRef->mTypeName;
                 else str<< "an empty object";
 
                 throw std::runtime_error(str.str());
@@ -85,7 +81,7 @@ namespace MWWorld
 
     inline bool operator== (const Ptr& left, const Ptr& right)
     {
-        return left.mRefData==right.mRefData;
+        return left.mRef==right.mRef;
     }
 
     inline bool operator!= (const Ptr& left, const Ptr& right)
@@ -95,7 +91,7 @@ namespace MWWorld
 
     inline bool operator< (const Ptr& left, const Ptr& right)
     {
-        return left.mRefData<right.mRefData;
+        return left.mRef<right.mRef;
     }
 
     inline bool operator>= (const Ptr& left, const Ptr& right)

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -46,8 +46,8 @@ namespace MWWorld
             template<typename T>
             MWWorld::LiveCellRef<T> *get() const
             {
-                if(mRef && mRef->mTypeName == typeid(T).name())
-                    return static_cast<MWWorld::LiveCellRef<T>*>(mRef);
+                MWWorld::LiveCellRef<T> *ref = dynamic_cast<MWWorld::LiveCellRef<T>*>(mRef);
+                if(ref) return ref;
 
                 std::stringstream str;
                 str<< "Bad LiveCellRef cast to "<<typeid(T).name()<<" from ";

--- a/apps/openmw/mwworld/ptr.hpp
+++ b/apps/openmw/mwworld/ptr.hpp
@@ -2,6 +2,7 @@
 #define GAME_MWWORLD_PTR_H
 
 #include "cellstore.hpp"
+#include "livecellref.hpp"
 
 namespace MWWorld
 {

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1446,7 +1446,7 @@ namespace MWWorld
 
         // Set OnPCDrop Variable on item's script, if it has a script with that variable declared
         if(script != "")
-            item.mRefData->getLocals().setVarByInt(script, "onpcdrop", 1);
+            item.getRefData().getLocals().setVarByInt(script, "onpcdrop", 1);
     }
 
     bool World::placeObject (const Ptr& object, float cursorX, float cursorY)
@@ -1764,7 +1764,7 @@ namespace MWWorld
             (*cellIt)->forEach<ListHandlesFunctor>(functor);
 
             for (std::vector<std::string>::iterator it = functor.mHandles.begin(); it != functor.mHandles.end(); ++it)
-                if (Misc::StringUtils::ciEqual(searchPtrViaHandle(*it).mCellRef->mOwner, npc.getCellRef().mRefID))
+                if (Misc::StringUtils::ciEqual(searchPtrViaHandle(*it).getCellRef().mOwner, npc.getCellRef().mRefID))
                     out.push_back(searchPtrViaHandle(*it));
         }
     }


### PR DESCRIPTION
This gets rid of the boost::any since all that's needed is a simple pointer to any LiveCellRef<> type. That and the string also incurred heap allocations every time a Ptr was copied or constructed with a LiveCellRef. They've been cleared up so creating/copying Ptr objects themselves should be much more efficient.

I've been considering storing a Class\* in the LiveCellRefBase also, so it only needs to be looked up once per LiveCellRef creation instead of every time Class::get(ptr) is called.
