### PR TITLE
Replaced std::pow with shift

### DIFF
--- a/components/terrain/chunk.cpp
+++ b/components/terrain/chunk.cpp
@@ -20,7 +20,7 @@ namespace Terrain
 
         // Set the total number of vertices
         size_t numVertsOneSide = mNode->getSize() * (ESM::Land::LAND_SIZE-1);
-        numVertsOneSide /= std::pow(2, lodLevel);
+        numVertsOneSide /= 1 << lodLevel;
         numVertsOneSide += 1;
         assert((int)numVertsOneSide == ESM::Land::LAND_SIZE);
         mVertexData->vertexCount = numVertsOneSide * numVertsOneSide;
@@ -92,7 +92,7 @@ namespace Terrain
             // Use 4 bits for each LOD delta
             if (lod > 0)
             {
-                assert (lod - ourLod < std::pow(2,4));
+                assert (lod - ourLod < (1 << 4));
                 flags |= int(lod - ourLod) << (4*i);
             }
         }

--- a/components/terrain/storage.cpp
+++ b/components/terrain/storage.cpp
@@ -131,7 +131,7 @@ namespace Terrain
                             Ogre::HardwareVertexBufferSharedPtr colourBuffer)
     {
         // LOD level n means every 2^n-th vertex is kept
-        size_t increment = std::pow(2, lodLevel);
+        size_t increment = 1 << lodLevel;
 
         Ogre::Vector2 origin = center - Ogre::Vector2(size/2.f, size/2.f);
         assert(origin.x == (int) origin.x);

--- a/components/terrain/terrain.cpp
+++ b/components/terrain/terrain.cpp
@@ -214,7 +214,7 @@ namespace Terrain
 
         bool anyDeltas = (lodDeltas[North] || lodDeltas[South] || lodDeltas[West] || lodDeltas[East]);
 
-        size_t increment = std::pow(2, lodLevel);
+        size_t increment = 1 << lodLevel;
         assert((int)increment < ESM::Land::LAND_SIZE);
         std::vector<short> indices;
         indices.reserve((ESM::Land::LAND_SIZE-1)*(ESM::Land::LAND_SIZE-1)*2*3 / increment);
@@ -251,7 +251,7 @@ namespace Terrain
 
             // South
             size_t row = 0;
-            size_t outerStep = std::pow(2, lodDeltas[South] + lodLevel);
+            size_t outerStep = 1 << (lodDeltas[South] + lodLevel);
             for (size_t col = 0; col < ESM::Land::LAND_SIZE-1; col += outerStep)
             {
                 indices.push_back(ESM::Land::LAND_SIZE*col+row);
@@ -275,7 +275,7 @@ namespace Terrain
 
             // North
             row = ESM::Land::LAND_SIZE-1;
-            outerStep = std::pow(2, lodDeltas[North] + lodLevel);
+            outerStep = 1 << (lodDeltas[North] + lodLevel);
             for (size_t col = 0; col < ESM::Land::LAND_SIZE-1; col += outerStep)
             {
                 indices.push_back(ESM::Land::LAND_SIZE*(col+outerStep)+row);
@@ -299,7 +299,7 @@ namespace Terrain
 
             // West
             size_t col = 0;
-            outerStep = std::pow(2, lodDeltas[West] + lodLevel);
+            outerStep = 1 << (lodDeltas[West] + lodLevel);
             for (size_t row = 0; row < ESM::Land::LAND_SIZE-1; row += outerStep)
             {
                 indices.push_back(ESM::Land::LAND_SIZE*col+row+outerStep);
@@ -323,7 +323,7 @@ namespace Terrain
 
             // East
             col = ESM::Land::LAND_SIZE-1;
-            outerStep = std::pow(2, lodDeltas[East] + lodLevel);
+            outerStep = 1 << (lodDeltas[East] + lodLevel);
             for (size_t row = 0; row < ESM::Land::LAND_SIZE-1; row += outerStep)
             {
                 indices.push_back(ESM::Land::LAND_SIZE*col+row);


### PR DESCRIPTION
Clang doesn't like int as a first argument of std::pow
