### PR TITLE
Improve hit detection

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -220,9 +220,10 @@ namespace MWBase
             virtual MWWorld::Ptr  getFacedObject() = 0;
             ///< Return pointer to the object the player is looking at, if it is within activation range
 
-            /// Returns a pointer to the object the provided object is facing (if within the
-            /// specified distance). This will attempt to use the "Bip01 Head" node as a basis.
-            virtual MWWorld::Ptr getFacedObject(const MWWorld::Ptr &ptr, float distance) = 0;
+            /// Returns a pointer to the object the provided object would hit (if within the
+            /// specified distance), and the point where the hit occurs. This will attempt to
+            /// use the "Head" node as a basis.
+            virtual std::pair<MWWorld::Ptr,Ogre::Vector3> getHitContact(const MWWorld::Ptr &ptr, float distance) = 0;
 
             virtual void adjustPosition (const MWWorld::Ptr& ptr) = 0;
             ///< Adjust position after load to be on ground. Must be called after model load.

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -332,7 +332,8 @@ namespace MWClass
         float dist = 100.0f * (!weapon.isEmpty() ?
                                weapon.get<ESM::Weapon>()->mBase->mData.mReach :
                                gmst.find("fHandToHandReach")->getFloat());
-        MWWorld::Ptr victim = world->getFacedObject(ptr, dist);
+        // TODO: Use second to work out the hit angle and where to spawn the blood effect
+        MWWorld::Ptr victim = world->getHitContact(ptr, dist).first;
         if(victim.isEmpty()) // Didn't hit anything
             return;
 

--- a/apps/openmw/mwworld/physicssystem.cpp
+++ b/apps/openmw/mwworld/physicssystem.cpp
@@ -311,7 +311,10 @@ namespace MWWorld
         return results;
     }
 
-    std::pair<std::string,float> PhysicsSystem::getFacedHandle(const Ogre::Vector3 &origin_, const Ogre::Quaternion &orient_, float queryDistance)
+    std::pair<std::string,Ogre::Vector3> PhysicsSystem::getHitContact(const std::string &name,
+                                                                      const Ogre::Vector3 &origin_,
+                                                                      const Ogre::Quaternion &orient_,
+                                                                      float queryDistance)
     {
         btVector3 origin(origin_.x, origin_.y, origin_.z);
 

--- a/apps/openmw/mwworld/physicssystem.cpp
+++ b/apps/openmw/mwworld/physicssystem.cpp
@@ -107,8 +107,7 @@ namespace MWWorld
         }
 
         static Ogre::Vector3 move(const MWWorld::Ptr &ptr, const Ogre::Vector3 &movement, float time,
-                                  bool isSwimming, bool isFlying, float waterlevel,
-                                  OEngine::Physic::PhysicEngine *engine)
+                                  bool isFlying, float waterlevel, OEngine::Physic::PhysicEngine *engine)
         {
             const ESM::Position &refpos = ptr.getRefData().getPosition();
             Ogre::Vector3 position(refpos.pos);
@@ -135,11 +134,11 @@ namespace MWWorld
             bool isOnGround = false;
             Ogre::Vector3 inertia(0.0f);
             Ogre::Vector3 velocity;
-            if(isSwimming || isFlying)
+            if(position.z < waterlevel || isFlying)
             {
-                velocity = (Ogre::Quaternion(Ogre::Radian( -refpos.rot[2]), Ogre::Vector3::UNIT_Z)*
-                            Ogre::Quaternion(Ogre::Radian( -refpos.rot[1]), Ogre::Vector3::UNIT_Y)*
-                            Ogre::Quaternion(Ogre::Radian(  refpos.rot[0]), Ogre::Vector3::UNIT_X)) *
+                velocity = (Ogre::Quaternion(Ogre::Radian(-refpos.rot[2]), Ogre::Vector3::UNIT_Z)*
+                            Ogre::Quaternion(Ogre::Radian(-refpos.rot[1]), Ogre::Vector3::UNIT_Y)*
+                            Ogre::Quaternion(Ogre::Radian( refpos.rot[0]), Ogre::Vector3::UNIT_X)) *
                            movement;
             }
             else
@@ -173,7 +172,7 @@ namespace MWWorld
             {
                 Ogre::Vector3 nextpos = newPosition + velocity*remainingTime;
 
-                if(isSwimming && !isFlying &&
+                if(newPosition.z < waterlevel && !isFlying &&
                    nextpos.z > waterlevel && newPosition.z <= waterlevel)
                 {
                     const Ogre::Vector3 down(0,0,-1);
@@ -197,7 +196,7 @@ namespace MWWorld
 
                 // We hit something. Try to step up onto it.
                 if(stepMove(colobj, newPosition, velocity, remainingTime, engine))
-                    isOnGround = !(isSwimming || isFlying); // Only on the ground if there's gravity
+                    isOnGround = !(newPosition.z < waterlevel || isFlying); // Only on the ground if there's gravity
                 else
                 {
                     // Can't move this way, try to find another spot along the plane
@@ -208,7 +207,7 @@ namespace MWWorld
 
                     // Do not allow sliding upward if there is gravity. Stepping will have taken
                     // care of that.
-                    if(!(isSwimming || isFlying))
+                    if(!(newPosition.z < waterlevel || isFlying))
                         velocity.z = std::min(velocity.z, 0.0f);
                 }
             }
@@ -225,7 +224,7 @@ namespace MWWorld
                     isOnGround = false;
             }
 
-            if(isOnGround || isSwimming || isFlying)
+            if(isOnGround || newPosition.z < waterlevel || isFlying)
                 physicActor->setInertialForce(Ogre::Vector3(0.0f));
             else
             {
@@ -590,15 +589,13 @@ namespace MWWorld
             for(;iter != mMovementQueue.end();iter++)
             {
                 float waterlevel = -std::numeric_limits<float>::max();
-                const MWWorld::CellStore *cellstore = iter->first.getCell();
-                if(cellstore->mCell->hasWater())
-                    waterlevel = cellstore->mCell->mWater;
+                const ESM::Cell *cell = iter->first.getCell()->mCell;
+                if(cell->hasWater())
+                    waterlevel = cell->mWater;
 
-                Ogre::Vector3 newpos;
-                newpos = MovementSolver::move(iter->first, iter->second, mTimeAccum,
-                                              world->isSwimming(iter->first),
-                                              world->isFlying(iter->first),
-                                              waterlevel, mEngine);
+                Ogre::Vector3 newpos = MovementSolver::move(iter->first, iter->second, mTimeAccum,
+                                                            world->isFlying(iter->first),
+                                                            waterlevel, mEngine);
                 mMovementResults.push_back(std::make_pair(iter->first, newpos));
             }
 

--- a/apps/openmw/mwworld/physicssystem.hpp
+++ b/apps/openmw/mwworld/physicssystem.hpp
@@ -57,9 +57,10 @@ namespace MWWorld
             Ogre::Vector3 traceDown(const MWWorld::Ptr &ptr);
 
             std::pair<float, std::string> getFacedHandle (MWWorld::World& world, float queryDistance);
-            std::pair<std::string,float> getFacedHandle(const Ogre::Vector3 &origin,
-                                                        const Ogre::Quaternion &orientation,
-                                                        float queryDistance);
+            std::pair<std::string,Ogre::Vector3> getHitContact(const std::string &name,
+                                                               const Ogre::Vector3 &origin,
+                                                               const Ogre::Quaternion &orientation,
+                                                               float queryDistance);
             std::vector < std::pair <float, std::string> > getFacedHandles (float queryDistance);
             std::vector < std::pair <float, std::string> > getFacedHandles (float mouseX, float mouseY, float queryDistance);
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -784,7 +784,7 @@ namespace MWWorld
         return object;
     }
 
-    MWWorld::Ptr World::getFacedObject(const MWWorld::Ptr &ptr, float distance)
+    std::pair<MWWorld::Ptr,Ogre::Vector3> World::getHitContact(const MWWorld::Ptr &ptr, float distance)
     {
         const ESM::Position &posdata = ptr.getRefData().getPosition();
         Ogre::Vector3 pos(posdata.pos);
@@ -799,11 +799,12 @@ namespace MWWorld
                 pos += node->_getDerivedPosition();
         }
 
-        std::pair<std::string,float> result = mPhysics->getFacedHandle(pos, rot, distance);
+        std::pair<std::string,Ogre::Vector3> result = mPhysics->getHitContact(ptr.getRefData().getHandle(),
+                                                                              pos, rot, distance);
         if(result.first.empty())
-            return MWWorld::Ptr();
+            return std::make_pair(MWWorld::Ptr(), Ogre::Vector3(0.0f));
 
-        return searchPtrViaHandle(result.first);
+        return std::make_pair(searchPtrViaHandle(result.first), result.second);
     }
 
     void World::deleteObject (const Ptr& ptr)

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -252,9 +252,10 @@ namespace MWWorld
             virtual MWWorld::Ptr getFacedObject();
             ///< Return pointer to the object the player is looking at, if it is within activation range
 
-            /// Returns a pointer to the object the provided object is facing (if within the
-            /// specified distance). This will attempt to use the "Bip01 Head" node as a basis.
-            virtual MWWorld::Ptr getFacedObject(const MWWorld::Ptr &ptr, float distance);
+            /// Returns a pointer to the object the provided object would hit (if within the
+            /// specified distance), and the point where the hit occurs. This will attempt to
+            /// use the "Head" node as a basis.
+            virtual std::pair<MWWorld::Ptr,Ogre::Vector3> getHitContact(const MWWorld::Ptr &ptr, float distance);
 
             virtual void deleteObject (const Ptr& ptr);
 

--- a/libs/openengine/bullet/physic.hpp
+++ b/libs/openengine/bullet/physic.hpp
@@ -321,9 +321,13 @@ public:
         std::pair<bool, float> sphereCast (float radius, btVector3& from, btVector3& to);
         ///< @return (hit, relative distance)
 
-        std::pair<std::string,btVector3> sphereTest(float radius,btVector3& pos);
-
         std::vector<std::string> getCollisions(const std::string& name);
+
+        // Get the nearest object that's inside the given object, filtering out objects of the
+        // provided name
+        std::pair<const RigidBody*,btVector3> getFilteredContact(const std::string &filter,
+                                                                 const btVector3 &origin,
+                                                                 btCollisionObject *object);
 
         //event list of non player object
         std::list<PhysicEvent> NPEventList;


### PR DESCRIPTION
Uses a proper cone shape and contact test to find the closest hit object, and makes it not player specific. Also adds a minor fix to stop the landing/splash sound from playing when walking out of water.
