### PR TITLE
Workaround for https://bugreports.qt-project.org/browse/QTBUG-22154

### DIFF
--- a/apps/launcher/graphicspage.cpp
+++ b/apps/launcher/graphicspage.cpp
@@ -3,6 +3,11 @@
 #include <QDesktopWidget>
 #include <QMessageBox>
 #include <QDir>
+
+#ifdef __APPLE__
+// We need to do this because of Qt: https://bugreports.qt-project.org/browse/QTBUG-22154
+#define MAC_OS_X_VERSION_MIN_REQUIRED __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
+#endif
 #include <SDL.h>
 
 #include <cstdlib>

--- a/apps/launcher/main.cpp
+++ b/apps/launcher/main.cpp
@@ -3,6 +3,10 @@
 #include <QDir>
 #include <QDebug>
 
+#ifdef __APPLE__
+// We need to do this because of Qt: https://bugreports.qt-project.org/browse/QTBUG-22154
+#define MAC_OS_X_VERSION_MIN_REQUIRED __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
+#endif
 #include <SDL.h>
 
 #include "maindialog.hpp"


### PR DESCRIPTION
Qt redefines min OS X version and SDL in turn checks this version and
doesn't accept version set by Qt and that leads to launcher build errors
