### PR TITLE
Bug #907

### DIFF
--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -585,7 +585,7 @@ namespace MWInput
                 mPlayer->pitch(-y/scale);
             }
 
-            if (arg.zrel)
+            if (arg.zrel && mControlSwitch["playerviewswitch"]) //Check to make sure you are allowed to zoomout and there is a change
             {
                 MWBase::Environment::get().getWorld()->changeVanityModeScale(arg.zrel);
                 MWBase::Environment::get().getWorld()->setCameraDistance(arg.zrel, true, true);

--- a/apps/openmw/mwmechanics/magiceffects.cpp
+++ b/apps/openmw/mwmechanics/magiceffects.cpp
@@ -151,8 +151,7 @@ namespace MWMechanics
         for (Collection::const_iterator iter (prev.begin()); iter!=prev.end(); ++iter)
         {
             Collection::const_iterator other = now.mCollection.find (iter->first);
-
-            if (other==prev.end())
+			if (other==now.end())
             {
                 result.add (iter->first, EffectParam() - iter->second);
             }


### PR DESCRIPTION
Added a check to make sure playerview is allowed when attempting to scroll, locking out zooming before character creation.

https://bugs.openmw.org/issues/907
Tested on Windows 64 bit, Visual Studio 2010 and works.
