### PR TITLE
Acrobatics

### DIFF
--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -324,6 +324,7 @@ namespace MWBase
             virtual void processChangedSettings (const Settings::CategorySettingVector& settings) = 0;
 
             virtual bool isFlying(const MWWorld::Ptr &ptr) const = 0;
+            virtual bool isSlowFalling(const MWWorld::Ptr &ptr) const = 0;
             virtual bool isSwimming(const MWWorld::Ptr &object) const = 0;
             ///Is the head of the creature underwater?
             virtual bool isSubmerged(const MWWorld::Ptr &object) const = 0;

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -769,6 +769,34 @@ namespace MWClass
         return x;
     }
 
+    float Npc::getFallDamage(const MWWorld::Ptr &ptr, float fallHeight) const
+    {
+        const float fallDistanceMin = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallDamageDistanceMin")->getFloat();
+
+        if (fallHeight>=fallDistanceMin)
+        {
+            const float acrobaticsSkill = MWWorld::Class::get(ptr).getNpcStats (ptr).getSkill(ESM::Skill::Acrobatics).getModified();
+            const CustomData *npcdata = static_cast<const CustomData*>(ptr.getRefData().getCustomData());
+            const float jumpSpellBonus = npcdata->mNpcStats.getMagicEffects().get(MWMechanics::EffectKey(9/*jump*/)).mMagnitude;
+            const float fallAcroBase = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallAcroBase")->getFloat();
+            const float fallAcroMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallAcroMult")->getFloat();
+            const float fallDistanceBase = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallDistanceBase")->getFloat();
+            const float fallDistanceMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallDistanceMult")->getFloat();
+
+            float x = fallHeight - fallDistanceMin;
+            x -= (1.5 * acrobaticsSkill) + jumpSpellBonus;
+            x = std::max(0.0f, x);
+
+            float a = fallAcroBase + fallAcroMult * (100 - acrobaticsSkill);
+            x = fallDistanceBase + fallDistanceMult * x;
+            x *= a;
+
+            return x;
+        }
+
+        return 0;
+    }
+
     MWMechanics::Movement& Npc::getMovementSettings (const MWWorld::Ptr& ptr) const
     {
         ensureCustomData (ptr);

--- a/apps/openmw/mwclass/npc.cpp
+++ b/apps/openmw/mwclass/npc.cpp
@@ -7,6 +7,7 @@
 
 #include <OgreSceneNode.h>
 
+#include <components/esm/loadmgef.hpp>
 #include <components/esm/loadnpc.hpp>
 
 #include "../mwbase/environment.hpp"
@@ -771,17 +772,20 @@ namespace MWClass
 
     float Npc::getFallDamage(const MWWorld::Ptr &ptr, float fallHeight) const
     {
-        const float fallDistanceMin = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallDamageDistanceMin")->getFloat();
+        MWBase::World *world = MWBase::Environment::get().getWorld();
+        const MWWorld::Store<ESM::GameSetting> &gmst = world->getStore().get<ESM::GameSetting>();
 
-        if (fallHeight>=fallDistanceMin)
+        const float fallDistanceMin = gmst.find("fFallDamageDistanceMin")->getFloat();
+
+        if (fallHeight >= fallDistanceMin)
         {
             const float acrobaticsSkill = MWWorld::Class::get(ptr).getNpcStats (ptr).getSkill(ESM::Skill::Acrobatics).getModified();
             const CustomData *npcdata = static_cast<const CustomData*>(ptr.getRefData().getCustomData());
-            const float jumpSpellBonus = npcdata->mNpcStats.getMagicEffects().get(MWMechanics::EffectKey(9/*jump*/)).mMagnitude;
-            const float fallAcroBase = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallAcroBase")->getFloat();
-            const float fallAcroMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallAcroMult")->getFloat();
-            const float fallDistanceBase = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallDistanceBase")->getFloat();
-            const float fallDistanceMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFallDistanceMult")->getFloat();
+            const float jumpSpellBonus = npcdata->mNpcStats.getMagicEffects().get(MWMechanics::EffectKey(ESM::MagicEffect::Jump)).mMagnitude;
+            const float fallAcroBase = gmst.find("fFallAcroBase")->getFloat();
+            const float fallAcroMult = gmst.find("fFallAcroMult")->getFloat();
+            const float fallDistanceBase = gmst.find("fFallDistanceBase")->getFloat();
+            const float fallDistanceMult = gmst.find("fFallDistanceMult")->getFloat();
 
             float x = fallHeight - fallDistanceMin;
             x -= (1.5 * acrobaticsSkill) + jumpSpellBonus;

--- a/apps/openmw/mwclass/npc.hpp
+++ b/apps/openmw/mwclass/npc.hpp
@@ -97,6 +97,9 @@ namespace MWClass
             virtual float getJump(const MWWorld::Ptr &ptr) const;
             ///< Return jump velocity (not accounting for movement)
 
+            virtual float getFallDamage(const MWWorld::Ptr &ptr, float fallHeight) const;
+            ///< Return amount of health points lost when falling
+
             virtual MWMechanics::Movement& getMovementSettings (const MWWorld::Ptr& ptr) const;
             ///< Return desired movement.
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -769,7 +769,7 @@ void CharacterController::update(float duration)
         if(sneak || inwater || flying)
         {
             vec.z = 0.0f;
-            mFallHeight = 0.0f;
+            mFallHeight = mPtr.getRefData().getPosition().pos[2];
         }
 
         if(!onground && !flying && !inwater)
@@ -854,7 +854,7 @@ void CharacterController::update(float duration)
                 }
             }
 
-            mFallHeight = 0;
+            mFallHeight = mPtr.getRefData().getPosition().pos[2];
         }
         else
         {

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -776,7 +776,15 @@ void CharacterController::update(float duration)
         {
             // The player is in the air (either getting up —ascending part of jump— or falling).
 
-            mFallHeight = std::max(mFallHeight, mPtr.getRefData().getPosition().pos[2]);
+            if (world->isSlowFalling(mPtr))
+            {
+                // SlowFalling spell effect is active, do not keep previous fall height
+                mFallHeight = mPtr.getRefData().getPosition().pos[2];
+            }
+            else
+            {
+                mFallHeight = std::max(mFallHeight, mPtr.getRefData().getPosition().pos[2]);
+            }
 
             const MWWorld::Store<ESM::GameSetting> &gmst = world->getStore().get<ESM::GameSetting>();
 

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -836,9 +836,11 @@ void CharacterController::update(float duration)
             float healthLost = cls.getFallDamage(mPtr, mFallHeight - mPtr.getRefData().getPosition().pos[2]);
             if (healthLost > 0.0f)
             {
+                const float fatigueTerm = cls.getCreatureStats(mPtr).getFatigueTerm();
+
                 // inflict fall damages
                 DynamicStat<float> health = cls.getCreatureStats(mPtr).getHealth();
-                int realHealthLost = healthLost * (1.0f - 0.25 * 1.25f /* * fatigueTerm */);
+                int realHealthLost = healthLost * (1.0f - 0.25 * fatigueTerm);
                 health.setCurrent(health.getCurrent() - realHealthLost);
                 cls.getCreatureStats(mPtr).setHealth(health);
 
@@ -846,7 +848,7 @@ void CharacterController::update(float duration)
                 cls.skillUsageSucceeded(mPtr, ESM::Skill::Acrobatics, 1);
 
                 const float acrobaticsSkill = cls.getNpcStats(mPtr).getSkill(ESM::Skill::Acrobatics).getModified();
-                if (healthLost > (acrobaticsSkill * 1.25f /* * fatigueTerm */))
+                if (healthLost > (acrobaticsSkill * fatigueTerm))
                 {
                     //TODO: actor falls over
                 }

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -813,17 +813,18 @@ void CharacterController::update(float duration)
             }
 
             // advance acrobatics
-            MWWorld::Class::get(mPtr).skillUsageSucceeded(mPtr, ESM::Skill::Acrobatics, 0);
+            cls.skillUsageSucceeded(mPtr, ESM::Skill::Acrobatics, 0);
 
             // decrease fatigue
-            const float fatigueJumpBase = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFatigueJumpBase")->getFloat();
-            const float fatigueJumpMult = MWBase::Environment::get().getWorld()->getStore().get<ESM::GameSetting>().find("fFatigueJumpMult")->getFloat();
+            const MWWorld::Store<ESM::GameSetting> &gmst = world->getStore().get<ESM::GameSetting>();
+            const float fatigueJumpBase = gmst.find("fFatigueJumpBase")->getFloat();
+            const float fatigueJumpMult = gmst.find("fFatigueJumpMult")->getFloat();
             const float normalizedEncumbrance = cls.getEncumbrance(mPtr) / cls.getCapacity(mPtr);
             const int fatigueDecrease = fatigueJumpBase + (1 - normalizedEncumbrance) * fatigueJumpMult;
-            DynamicStat<float> fatigue = cls.getCreatureStats(mPtr).getDynamic(2);
+            DynamicStat<float> fatigue = cls.getCreatureStats(mPtr).getFatigue();
             fatigue.setModified(fatigue.getModified() - fatigueDecrease, 0);
             fatigue.setCurrent(fatigue.getCurrent() - fatigueDecrease);
-            cls.getCreatureStats(mPtr).setDynamic(2, fatigue);
+            cls.getCreatureStats(mPtr).setFatigue(fatigue);
         }
         else if(mJumpState == JumpState_Falling)
         {
@@ -838,10 +839,9 @@ void CharacterController::update(float duration)
             {
                 // inflict fall damages
                 DynamicStat<float> health = cls.getCreatureStats(mPtr).getHealth();
-                int current = health.getCurrent();
                 int realHealthLost = healthLost * (1.0f - 0.25 * 1.25f /* * fatigueTerm */);
                 health.setModified(health.getModified() - realHealthLost, 0);
-                health.setCurrent(current - realHealthLost);
+                health.setCurrent(health.getCurrent() - realHealthLost);
                 cls.getCreatureStats(mPtr).setHealth(health);
 
                 // report acrobatics progression

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -822,7 +822,6 @@ void CharacterController::update(float duration)
             const float normalizedEncumbrance = cls.getEncumbrance(mPtr) / cls.getCapacity(mPtr);
             const int fatigueDecrease = fatigueJumpBase + (1 - normalizedEncumbrance) * fatigueJumpMult;
             DynamicStat<float> fatigue = cls.getCreatureStats(mPtr).getFatigue();
-            fatigue.setModified(fatigue.getModified() - fatigueDecrease, 0);
             fatigue.setCurrent(fatigue.getCurrent() - fatigueDecrease);
             cls.getCreatureStats(mPtr).setFatigue(fatigue);
         }
@@ -840,7 +839,6 @@ void CharacterController::update(float duration)
                 // inflict fall damages
                 DynamicStat<float> health = cls.getCreatureStats(mPtr).getHealth();
                 int realHealthLost = healthLost * (1.0f - 0.25 * 1.25f /* * fatigueTerm */);
-                health.setModified(health.getModified() - realHealthLost, 0);
                 health.setCurrent(health.getCurrent() - realHealthLost);
                 cls.getCreatureStats(mPtr).setHealth(health);
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -3,6 +3,8 @@
 
 #include <OgreVector3.h>
 
+#include <components/esm/loadmgef.hpp>
+
 #include "../mwworld/ptr.hpp"
 
 namespace MWWorld

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -154,6 +154,9 @@ class CharacterController
     float mSecondsOfSwimming;
     float mSecondsOfRunning;
 
+    // used for acrobatics progress and fall damages
+    float mFallHeight;
+
     std::string mAttackType; // slash, chop or thrust
 
     void refreshCurrentAnims(CharacterState idle, CharacterState movement, bool force=false);

--- a/apps/openmw/mwworld/class.cpp
+++ b/apps/openmw/mwworld/class.cpp
@@ -167,6 +167,11 @@ namespace MWWorld
         throw std::runtime_error ("class does not support enchanting");
     }
 
+    float Class::getFallDamage(const MWWorld::Ptr &ptr, float fallHeight) const
+    {
+        return 0;
+    }
+
     MWMechanics::Movement& Class::getMovementSettings (const Ptr& ptr) const
     {
         throw std::runtime_error ("movement settings not supported by class");

--- a/apps/openmw/mwworld/class.hpp
+++ b/apps/openmw/mwworld/class.hpp
@@ -175,6 +175,9 @@ namespace MWWorld
             virtual float getJump(const MWWorld::Ptr &ptr) const;
             ///< Return jump velocity (not accounting for movement)
 
+            virtual float getFallDamage(const MWWorld::Ptr &ptr, float fallHeight) const;
+            ///< Return amount of health points lost when falling
+
             virtual MWMechanics::Movement& getMovementSettings (const Ptr& ptr) const;
             ///< Return desired movement.
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -1582,6 +1582,19 @@ namespace MWWorld
         return false;
     }
 
+    bool
+    World::isSlowFalling(const MWWorld::Ptr &ptr) const
+    {
+        if(!ptr.getClass().isActor())
+            return false;
+
+        const MWMechanics::CreatureStats &stats = ptr.getClass().getCreatureStats(ptr);
+        if(stats.getMagicEffects().get(MWMechanics::EffectKey(ESM::MagicEffect::SlowFall)).mMagnitude > 0)
+            return true;
+
+        return false;
+    }
+
     bool World::isSubmerged(const MWWorld::Ptr &object) const
     {
         float *fpos = object.getRefData().getPosition().pos;

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -355,6 +355,7 @@ namespace MWWorld
             virtual void processChangedSettings(const Settings::CategorySettingVector& settings);
 
             virtual bool isFlying(const MWWorld::Ptr &ptr) const;
+            virtual bool isSlowFalling(const MWWorld::Ptr &ptr) const;
             ///Is the head of the creature underwater?
             virtual bool isSubmerged(const MWWorld::Ptr &object) const;
             virtual bool isSwimming(const MWWorld::Ptr &object) const;


### PR DESCRIPTION
Apply fall damages, unless player is slowfalling or flying.
Advance Acrobatics skill on jump and when fall damages are taken.
Decrease fatigue on jump.

During my testing, I noticed that the player's fatigue does not refill.
Also, player death animation is funky in 1st person, and is played again when switching from 1st to 3rd person.
