### PR TITLE
Bug #794

### DIFF
--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -2,6 +2,9 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <sstream>
+#include <iomanip>
+
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
@@ -174,7 +177,9 @@ namespace MWGui
                     if (it->first == 84) // special handling for fortify maximum magicka
                     {
                         std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
-                        sourcesDescription += " " + boost::lexical_cast<std::string>(effectIt->mMagnitude / 10.0f) + timesInt;
+                        std::stringstream formatter;
+                        formatter << std::fixed << std::setprecision(1) << " " << (effectIt->mMagnitude / 10.0f) << timesInt;
+                        sourcesDescription += formatter.str();
                     }
                     else
                     {

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -171,11 +171,26 @@ namespace MWGui
 
                 if (!(effect->mData.mFlags & ESM::MagicEffect::NoMagnitude))
                 {
-                    std::string pt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
-                    std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
+                    if (it->first == 84) // special handling for fortify maximum magicka
+                    {
+                        std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
+                        sourcesDescription += " " + boost::lexical_cast<std::string>(effectIt->mMagnitude / 10.0f) + timesInt;
+                    }
+                    else
+                    {
+                        std::string pt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
+                        std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
+                        std::string pct =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
+                        const bool usePct = (
+                            (it->first >= 28 && it->first <= 36) || // Weakness effects
+                            (it->first >= 90 && it->first <= 99) ); // Resistance effects
 
-                    sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude);
-                    sourcesDescription += " " + ((effectIt->mMagnitude > 1) ? pts : pt);
+                        sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude) + " ";
+                        if ( usePct )
+                            sourcesDescription += pct;
+                        else
+                            sourcesDescription += ((effectIt->mMagnitude > 1) ? pts : pt);
+                    }
                 }
             }
 

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -190,11 +190,11 @@ namespace MWGui
                             (it->first >= 28 && it->first <= 36) || // Weakness effects
                             (it->first >= 90 && it->first <= 99) ); // Resistance effects
 
-                        sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude) + " ";
+                        sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude);
                         if ( usePct )
                             sourcesDescription += pct;
                         else
-                            sourcesDescription += ((effectIt->mMagnitude > 1) ? pts : pt);
+                            sourcesDescription += " " + ((effectIt->mMagnitude > 1) ? pts : pt);
                     }
                 }
             }

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -2,6 +2,9 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <sstream>
+#include <iomanip>
+
 #include <MyGUI_ProgressBar.h>
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_ControllerManager.h>
@@ -429,12 +432,14 @@ namespace MWGui
                 {
                     std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
                     std::string times =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimes", "");
-                    if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin / 10.0f) + timesInt;
-                    else
-                    {
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin / 10.0f) + times + " " + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax / 10.0f) + timesInt;
-                    }
+                    std::stringstream formatter;
+
+                    formatter << std::fixed << std::setprecision(1) << " " << (mEffectParams.mMagnMin / 10.0f);
+                    if (mEffectParams.mMagnMin != mEffectParams.mMagnMax)
+                        formatter << times << " " << to << " " << (mEffectParams.mMagnMax / 10.0f);
+                    formatter << timesInt;
+
+                    spellLine += formatter.str();
                 }
                 else
                 {

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -447,15 +447,15 @@ namespace MWGui
                         (mEffectParams.mEffectID >= 28 && mEffectParams.mEffectID <= 36) || // Weakness effects
                         (mEffectParams.mEffectID >= 90 && mEffectParams.mEffectID <= 99) ); // Resistance effects
                     if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + " ";
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin);
                     else
                     {
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax) + " ";
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax);
                     }
                     if ( usePct )
                         spellLine += pct;
                     else
-                        spellLine += ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
+                        spellLine += " " + ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
                 }
             }
 

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -405,6 +405,7 @@ namespace MWGui
 
             std::string pt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
             std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
+            std::string pct =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
             std::string to =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "") + " ";
             std::string sec =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("ssecond", "");
             std::string secs =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("sseconds", "");
@@ -423,11 +424,33 @@ namespace MWGui
 
             if ((mEffectParams.mMagnMin >= 0 || mEffectParams.mMagnMax >= 0) && !(magicEffect->mData.mFlags & ESM::MagicEffect::NoMagnitude))
             {
-                if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
-                    spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + " " + ((mEffectParams.mMagnMin == 1) ? pt : pts);
+                // Fortify Maximum Magicka display rules:
+                if ( mEffectParams.mEffectID == 84 )
+                {
+                    std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
+                    std::string times =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimes", "");
+                    if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin / 10.0f) + timesInt;
+                    else
+                    {
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin / 10.0f) + times + " " + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax / 10.0f) + timesInt;
+                    }
+                }
                 else
                 {
-                    spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax) + " " + pts;
+                    const bool usePct = (
+                        (mEffectParams.mEffectID >= 28 && mEffectParams.mEffectID <= 36) || // Weakness effects
+                        (mEffectParams.mEffectID >= 90 && mEffectParams.mEffectID <= 99) ); // Resistance effects
+                    if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + " ";
+                    else
+                    {
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax) + " ";
+                    }
+                    if ( usePct )
+                        spellLine += pct;
+                    else
+                        spellLine += ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
                 }
             }
 


### PR DESCRIPTION
Some magic effect display updates.

Fortify Max Magicka now uses "#x INT" display format, pulling strings from the appropriate game settings.

Partial changes for percentage based display made, since it was handled by the same code.  The percentage display rule should probably be moved to a magic effect struct property; the effect list for this is incomplete, but displays the new functionality (weaknesses/resistances handled).
