### PR TITLE
Topic/magic effect display format

### DIFF
--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -172,7 +172,7 @@ namespace MWGui
                             MWBase::Environment::get().getWindowManager()->getGameSettingString(
                                 ESM::Attribute::sGmstAttributeIds[effectIt->mKey.mArg], "") + ")";
 
-                int displayType = effect->getMagnitudeDisplayType();
+                ESM::MagicEffect::MagnitudeDisplayType displayType = effect->getMagnitudeDisplayType();
                 if (displayType == ESM::MagicEffect::MDT_TimesInt)
                 {
                     std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
@@ -182,15 +182,24 @@ namespace MWGui
                 }
                 else if ( displayType != ESM::MagicEffect::MDT_None )
                 {
-                    std::string pt  =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
-                    std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
-                    std::string pct =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
-
                     sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude);
+
                     if ( displayType == ESM::MagicEffect::MDT_Percentage )
-                        sourcesDescription += pct;
+                        sourcesDescription += MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
+                    else if ( displayType == ESM::MagicEffect::MDT_Feet )
+                        sourcesDescription += " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("sfeet", "");
+                    else if ( displayType == ESM::MagicEffect::MDT_Level )
+                    {
+                        sourcesDescription += " " + ((effectIt->mMagnitude > 1) ?
+                            MWBase::Environment::get().getWindowManager()->getGameSettingString("sLevels", "") :
+                            MWBase::Environment::get().getWindowManager()->getGameSettingString("sLevel", "") );
+                    }
                     else // ESM::MagicEffect::MDT_Points
-                        sourcesDescription += " " + ((effectIt->mMagnitude > 1) ? pts : pt);
+                    {
+                        sourcesDescription += " " + ((effectIt->mMagnitude > 1) ?
+                            MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "") :
+                            MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "") );
+                    }
                 }
             }
 

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -2,6 +2,9 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <sstream>
+#include <iomanip>
+
 #include "../mwbase/world.hpp"
 #include "../mwbase/environment.hpp"
 #include "../mwbase/windowmanager.hpp"
@@ -174,7 +177,9 @@ namespace MWGui
                     if (it->first == 84) // special handling for fortify maximum magicka
                     {
                         std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
-                        sourcesDescription += " " + boost::lexical_cast<std::string>(effectIt->mMagnitude / 10.0f) + timesInt;
+                        std::stringstream formatter;
+                        formatter << std::fixed << std::setprecision(1) << " " << (effectIt->mMagnitude / 10.0f) << timesInt;
+                        sourcesDescription += formatter.str();
                     }
                     else
                     {

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -171,11 +171,26 @@ namespace MWGui
 
                 if (!(effect->mData.mFlags & ESM::MagicEffect::NoMagnitude))
                 {
-                    std::string pt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
-                    std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
+                    if (it->first == 84) // special handling for fortify maximum magicka
+                    {
+                        std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
+                        sourcesDescription += " " + boost::lexical_cast<std::string>(effectIt->mMagnitude / 10.0f) + timesInt;
+                    }
+                    else
+                    {
+                        std::string pt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
+                        std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
+                        std::string pct =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
+                        const bool usePct = (
+                            (it->first >= 28 && it->first <= 36) || // Weakness effects
+                            (it->first >= 90 && it->first <= 99) ); // Resistance effects
 
-                    sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude);
-                    sourcesDescription += " " + ((effectIt->mMagnitude > 1) ? pts : pt);
+                        sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude) + " ";
+                        if ( usePct )
+                            sourcesDescription += pct;
+                        else
+                            sourcesDescription += ((effectIt->mMagnitude > 1) ? pts : pt);
+                    }
                 }
             }
 

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -190,11 +190,11 @@ namespace MWGui
                             (it->first >= 28 && it->first <= 36) || // Weakness effects
                             (it->first >= 90 && it->first <= 99) ); // Resistance effects
 
-                        sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude) + " ";
+                        sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude);
                         if ( usePct )
                             sourcesDescription += pct;
                         else
-                            sourcesDescription += ((effectIt->mMagnitude > 1) ? pts : pt);
+                            sourcesDescription += " " + ((effectIt->mMagnitude > 1) ? pts : pt);
                     }
                 }
             }

--- a/apps/openmw/mwgui/spellicons.cpp
+++ b/apps/openmw/mwgui/spellicons.cpp
@@ -172,30 +172,25 @@ namespace MWGui
                             MWBase::Environment::get().getWindowManager()->getGameSettingString(
                                 ESM::Attribute::sGmstAttributeIds[effectIt->mKey.mArg], "") + ")";
 
-                if (!(effect->mData.mFlags & ESM::MagicEffect::NoMagnitude))
+                int displayType = effect->getMagnitudeDisplayType();
+                if (displayType == ESM::MagicEffect::MDT_TimesInt)
                 {
-                    if (it->first == 84) // special handling for fortify maximum magicka
-                    {
-                        std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
-                        std::stringstream formatter;
-                        formatter << std::fixed << std::setprecision(1) << " " << (effectIt->mMagnitude / 10.0f) << timesInt;
-                        sourcesDescription += formatter.str();
-                    }
-                    else
-                    {
-                        std::string pt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
-                        std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
-                        std::string pct =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
-                        const bool usePct = (
-                            (it->first >= 28 && it->first <= 36) || // Weakness effects
-                            (it->first >= 90 && it->first <= 99) ); // Resistance effects
+                    std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
+                    std::stringstream formatter;
+                    formatter << std::fixed << std::setprecision(1) << " " << (effectIt->mMagnitude / 10.0f) << timesInt;
+                    sourcesDescription += formatter.str();
+                }
+                else if ( displayType != ESM::MagicEffect::MDT_None )
+                {
+                    std::string pt  =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
+                    std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
+                    std::string pct =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
 
-                        sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude);
-                        if ( usePct )
-                            sourcesDescription += pct;
-                        else
-                            sourcesDescription += " " + ((effectIt->mMagnitude > 1) ? pts : pt);
-                    }
+                    sourcesDescription += ": " + boost::lexical_cast<std::string>(effectIt->mMagnitude);
+                    if ( displayType == ESM::MagicEffect::MDT_Percentage )
+                        sourcesDescription += pct;
+                    else // ESM::MagicEffect::MDT_Points
+                        sourcesDescription += " " + ((effectIt->mMagnitude > 1) ? pts : pt);
                 }
             }
 

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -409,6 +409,9 @@ namespace MWGui
             std::string pt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
             std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
             std::string pct =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
+            std::string ft =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sfeet", "");
+            std::string lvl =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sLevel", "");
+            std::string lvls =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sLevels", "");
             std::string to =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "") + " ";
             std::string sec =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("ssecond", "");
             std::string secs =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("sseconds", "");
@@ -426,15 +429,14 @@ namespace MWGui
             }
 
             if (mEffectParams.mMagnMin >= 0 || mEffectParams.mMagnMax >= 0) {
-                int displayType = magicEffect->getMagnitudeDisplayType();
+                ESM::MagicEffect::MagnitudeDisplayType displayType = magicEffect->getMagnitudeDisplayType();
                 if ( displayType == ESM::MagicEffect::MDT_TimesInt ) {
                     std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
-                    std::string times =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimes", "");
                     std::stringstream formatter;
 
                     formatter << std::fixed << std::setprecision(1) << " " << (mEffectParams.mMagnMin / 10.0f);
                     if (mEffectParams.mMagnMin != mEffectParams.mMagnMax)
-                        formatter << times << to << (mEffectParams.mMagnMax / 10.0f);
+                        formatter << to << (mEffectParams.mMagnMax / 10.0f);
                     formatter << timesInt;
 
                     spellLine += formatter.str();
@@ -446,6 +448,10 @@ namespace MWGui
 
                     if ( displayType == ESM::MagicEffect::MDT_Percentage )
                         spellLine += pct;
+                    else if ( displayType == ESM::MagicEffect::MDT_Feet )
+                        spellLine += " " + ft;
+                    else if ( displayType == ESM::MagicEffect::MDT_Level )
+                        spellLine += " " + ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? lvl : lvls );
                     else  // ESM::MagicEffect::MDT_Points
                         spellLine += " " + ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
                 }

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -2,6 +2,9 @@
 
 #include <boost/lexical_cast.hpp>
 
+#include <sstream>
+#include <iomanip>
+
 #include <MyGUI_ProgressBar.h>
 #include <MyGUI_ImageBox.h>
 #include <MyGUI_ControllerManager.h>
@@ -429,12 +432,14 @@ namespace MWGui
                 {
                     std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
                     std::string times =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimes", "");
-                    if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin / 10.0f) + timesInt;
-                    else
-                    {
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin / 10.0f) + times + " " + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax / 10.0f) + timesInt;
-                    }
+                    std::stringstream formatter;
+
+                    formatter << std::fixed << std::setprecision(1) << " " << (mEffectParams.mMagnMin / 10.0f);
+                    if (mEffectParams.mMagnMin != mEffectParams.mMagnMax)
+                        formatter << times << " " << to << " " << (mEffectParams.mMagnMax / 10.0f);
+                    formatter << timesInt;
+
+                    spellLine += formatter.str();
                 }
                 else
                 {

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -425,11 +425,9 @@ namespace MWGui
                 spellLine += " " + MWBase::Environment::get().getWindowManager()->getGameSettingString(ESM::Attribute::sGmstAttributeIds[mEffectParams.mAttribute], "");
             }
 
-            if ((mEffectParams.mMagnMin >= 0 || mEffectParams.mMagnMax >= 0) && !(magicEffect->mData.mFlags & ESM::MagicEffect::NoMagnitude))
-            {
-                // Fortify Maximum Magicka display rules:
-                if ( mEffectParams.mEffectID == 84 )
-                {
+            if (mEffectParams.mMagnMin >= 0 || mEffectParams.mMagnMax >= 0) {
+                int displayType = magicEffect->getMagnitudeDisplayType();
+                if ( displayType == ESM::MagicEffect::MDT_TimesInt ) {
                     std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
                     std::string times =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimes", "");
                     std::stringstream formatter;
@@ -441,20 +439,14 @@ namespace MWGui
 
                     spellLine += formatter.str();
                 }
-                else
-                {
-                    const bool usePct = (
-                        (mEffectParams.mEffectID >= 28 && mEffectParams.mEffectID <= 36) || // Weakness effects
-                        (mEffectParams.mEffectID >= 90 && mEffectParams.mEffectID <= 99) ); // Resistance effects
-                    if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin);
-                    else
-                    {
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax);
-                    }
-                    if ( usePct )
+                else if ( displayType != ESM::MagicEffect::MDT_None ) {
+                    spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin);
+                    if (mEffectParams.mMagnMin != mEffectParams.mMagnMax)
+                        spellLine += to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax);
+
+                    if ( displayType == ESM::MagicEffect::MDT_Percentage )
                         spellLine += pct;
-                    else
+                    else  // ESM::MagicEffect::MDT_Points
                         spellLine += " " + ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
                 }
             }

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -447,15 +447,15 @@ namespace MWGui
                         (mEffectParams.mEffectID >= 28 && mEffectParams.mEffectID <= 36) || // Weakness effects
                         (mEffectParams.mEffectID >= 90 && mEffectParams.mEffectID <= 99) ); // Resistance effects
                     if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + " ";
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin);
                     else
                     {
-                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax) + " ";
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax);
                     }
                     if ( usePct )
                         spellLine += pct;
                     else
-                        spellLine += ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
+                        spellLine += " " + ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
                 }
             }
 

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -436,7 +436,7 @@ namespace MWGui
 
                     formatter << std::fixed << std::setprecision(1) << " " << (mEffectParams.mMagnMin / 10.0f);
                     if (mEffectParams.mMagnMin != mEffectParams.mMagnMax)
-                        formatter << times << " " << to << " " << (mEffectParams.mMagnMax / 10.0f);
+                        formatter << times << to << (mEffectParams.mMagnMax / 10.0f);
                     formatter << timesInt;
 
                     spellLine += formatter.str();

--- a/apps/openmw/mwgui/widgets.cpp
+++ b/apps/openmw/mwgui/widgets.cpp
@@ -405,6 +405,7 @@ namespace MWGui
 
             std::string pt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoint", "");
             std::string pts =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spoints", "");
+            std::string pct =  MWBase::Environment::get().getWindowManager()->getGameSettingString("spercent", "");
             std::string to =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("sTo", "") + " ";
             std::string sec =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("ssecond", "");
             std::string secs =  " " + MWBase::Environment::get().getWindowManager()->getGameSettingString("sseconds", "");
@@ -423,11 +424,33 @@ namespace MWGui
 
             if ((mEffectParams.mMagnMin >= 0 || mEffectParams.mMagnMax >= 0) && !(magicEffect->mData.mFlags & ESM::MagicEffect::NoMagnitude))
             {
-                if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
-                    spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + " " + ((mEffectParams.mMagnMin == 1) ? pt : pts);
+                // Fortify Maximum Magicka display rules:
+                if ( mEffectParams.mEffectID == 84 )
+                {
+                    std::string timesInt =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimesINT", "");
+                    std::string times =  MWBase::Environment::get().getWindowManager()->getGameSettingString("sXTimes", "");
+                    if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin / 10.0f) + timesInt;
+                    else
+                    {
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin / 10.0f) + times + " " + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax / 10.0f) + timesInt;
+                    }
+                }
                 else
                 {
-                    spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax) + " " + pts;
+                    const bool usePct = (
+                        (mEffectParams.mEffectID >= 28 && mEffectParams.mEffectID <= 36) || // Weakness effects
+                        (mEffectParams.mEffectID >= 90 && mEffectParams.mEffectID <= 99) ); // Resistance effects
+                    if (mEffectParams.mMagnMin == mEffectParams.mMagnMax)
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + " ";
+                    else
+                    {
+                        spellLine += " " + boost::lexical_cast<std::string>(mEffectParams.mMagnMin) + to + boost::lexical_cast<std::string>(mEffectParams.mMagnMax) + " ";
+                    }
+                    if ( usePct )
+                        spellLine += pct;
+                    else
+                        spellLine += ((mEffectParams.mMagnMin == 1 && mEffectParams.mMagnMax == 1) ? pt : pts );
                 }
             }
 

--- a/components/esm/loadmgef.cpp
+++ b/components/esm/loadmgef.cpp
@@ -279,8 +279,15 @@ MagicEffect::MagnitudeDisplayType MagicEffect::getMagnitudeDisplayType() const {
         return MDT_None;
     if ( mIndex == 84 )
         return MDT_TimesInt;
+    if ( mIndex == 59 ||
+        ( mIndex >= 64 && mIndex <= 66) )
+        return MDT_Feet;
+    if ( mIndex == 118 || mIndex == 119 )
+        return MDT_Level;
     if (   ( mIndex >= 28 && mIndex <= 36 )
-        || ( mIndex >= 90 && mIndex <= 99 ) )
+        || ( mIndex >= 90 && mIndex <= 99 )
+        ||   mIndex == 40 || mIndex == 47
+        ||   mIndex == 57 || mIndex == 68 )
         return MDT_Percentage;
 
     return MDT_Points;

--- a/components/esm/loadmgef.cpp
+++ b/components/esm/loadmgef.cpp
@@ -274,5 +274,16 @@ short MagicEffect::effectStringToId(const std::string &effect)
     return name->first;
 }
 
+MagicEffect::MagnitudeDisplayType MagicEffect::getMagnitudeDisplayType() const {
+    if ( mData.mFlags & NoMagnitude )
+        return MDT_None;
+    if ( mIndex == 84 )
+        return MDT_TimesInt;
+    if (   ( mIndex >= 28 && mIndex <= 36 )
+        || ( mIndex >= 90 && mIndex <= 99 ) )
+        return MDT_Percentage;
+
+    return MDT_Points;
+}
 
 }

--- a/components/esm/loadmgef.hpp
+++ b/components/esm/loadmgef.hpp
@@ -35,8 +35,10 @@ struct MagicEffect
     enum MagnitudeDisplayType
     {
         MDT_None,
-        MDT_Points,
+        MDT_Feet,
+        MDT_Level,
         MDT_Percentage,
+        MDT_Points,
         MDT_TimesInt
     };
 

--- a/components/esm/loadmgef.hpp
+++ b/components/esm/loadmgef.hpp
@@ -32,6 +32,13 @@ struct MagicEffect
         Negative = 0x0800 // A harmful effect. Will determine whether
                           // eg. NPCs regard this spell as an attack. (same as 0x10?)
     };
+    enum MagnitudeDisplayType
+    {
+        MDT_None,
+        MDT_Points,
+        MDT_Percentage,
+        MDT_TimesInt
+    };
 
     struct MEDTstruct
     {
@@ -47,6 +54,7 @@ struct MagicEffect
 
     static const std::string &effectIdToString(short effectID);
     static short effectStringToId(const std::string &effect);
+    MagnitudeDisplayType getMagnitudeDisplayType() const;
 
 
     MEDTstruct mData;


### PR DESCRIPTION
This should update the gui to use the appropriate units and scale for magic effect magnitudes.

Fixes bug #794.
