### PR TITLE
Breath meter enhancements

### DIFF
--- a/apps/openmw/mwgui/hud.hpp
+++ b/apps/openmw/mwgui/hud.hpp
@@ -67,7 +67,7 @@ namespace MWGui
         MyGUI::ImageBox* mCrosshair;
         MyGUI::TextBox* mCellNameBox;
         MyGUI::TextBox* mWeaponSpellBox;
-        MyGUI::Widget* mDrowningFrame;
+        MyGUI::Widget *mDrowningFrame, *mDrowningFlash;
 
         MyGUI::Widget* mDummy;
 
@@ -100,6 +100,9 @@ namespace MWGui
 
         MWWorld::Ptr mEnemy;
         float mEnemyHealthTimer;
+
+        bool  mIsDrowning;
+        float mDrowningFlashTheta;
 
         void onWorldClicked(MyGUI::Widget* _sender);
         void onWorldMouseOver(MyGUI::Widget* _sender, int x, int y);

--- a/files/mygui/openmw_hud.layout
+++ b/files/mygui/openmw_hud.layout
@@ -45,6 +45,7 @@
             <Widget type="ProgressBar" skin="MW_Progress_Loading" position="12 36 196 8" align="Center Top" name="Drowning">
                 <Property key="NeedMouse" value="false"/>
             </Widget>
+            <Widget type="Widget" skin="MW_Progress_Drowning" position="14 38 192 4" align="Center Top" name="Flash"/>
         </Widget>
 
         <!-- Equipped weapon/selected spell name display for a few seconds after it changes -->

--- a/files/mygui/openmw_progress.skin.xml
+++ b/files/mygui/openmw_progress.skin.xml
@@ -17,6 +17,11 @@
             <State name="normal" offset="0 28 2 14"/>
         </BasisSkin>
     </Skin>
+    <Skin name="MW_BigTrack_Progress_Red_Small" size="2 6" texture="smallbars.png" >
+        <BasisSkin type="MainSkin" offset="0 0 2 6" align="Stretch">
+            <State name="normal" offset="0 0 2 8"/>
+        </BasisSkin>
+    </Skin>
     <Skin name="MW_BigTrack_Progress_Blue_Small" size="2 6" texture="smallbars.png" >
         <BasisSkin type="MainSkin" offset="0 0 2 6" align="Stretch">
             <State name="normal" offset="0 26 2 6"/>
@@ -63,6 +68,10 @@
 
         <Child type="Widget" skin="MW_Box" offset="0 0 64 6" align="Stretch"/>
         <Child type="Widget" skin="BlackBG" offset="2 2 60 2" align="Stretch" name="Client"/>
+    </Skin>
+
+    <Skin name="MW_Progress_Drowning" size="64 6">
+        <Child type="Widget" skin="MW_BigTrack_Progress_Red_Small" offset="0 0 64 6" align="Stretch"/>
     </Skin>
 
     <Skin name="MW_ProgressScroll_Loading" size="64 6">


### PR DESCRIPTION
Fixing issue 898. http://bugs.openmw.org/issues/898

As an alternative to copypasting the code from MyGUI, or rewriting the progress bar, a much simpler, less hackish solution was found: add a hidden generic bar widget on top of the meter, and pulse it from red to black using setColour().
