### PR TITLE
Corrected compilation error (g++ 4.8.2)

### DIFF
--- a/apps/opencs/model/world/idcollection.hpp
+++ b/apps/opencs/model/world/idcollection.hpp
@@ -111,7 +111,7 @@ namespace CSMWorld
         else
         {
             record.mState = RecordBase::State_Deleted;
-            setRecord (index, record);
+            this->setRecord (index, record);
         }
 
         return true;


### PR DESCRIPTION
Corrected compilation error (g++ 4.8.2) triggered by not found declaration
in argument-dependent lookup at the point of instantiation.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
