### PR TITLE
Fixes #597: Assertion `dialogue->mId == id' failed in esmstore.cpp

### DIFF
--- a/apps/openmw/mwworld/esmstore.cpp
+++ b/apps/openmw/mwworld/esmstore.cpp
@@ -100,11 +100,7 @@ void ESMStore::load(ESM::ESMReader &esm, Loading::Listener* listener)
             it->second->load(esm, id);
 
             if (n.val==ESM::REC_DIAL) {
-                // dirty hack, but it is better than non-const search()
-                // or friends
-                //dialogue = &mDialogs.mStatic.back();
                 dialogue = const_cast<ESM::Dialogue*>(mDialogs.find(id));
-                assert (dialogue->mId == id);
             } else {
                 dialogue = 0;
             }


### PR DESCRIPTION
It seems that assertion was unnecessary, after removing it, dialogues
related to moon-and-star in "Path of the Incarnate" quest were
correctly loaded (dumped DialInfo records were correct).

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
