### PR TITLE
Introduce -DBUILD_WITH_DPKG to toggle dpkg based install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,10 @@ option(USE_MPG123 "use mpg123 + libsndfile for sound" ON)
 # OS X deployment
 option(OPENMW_OSX_DEPLOYMENT OFF)
 
-find_program(DPKG_PROGRAM dpkg DOC "dpkg program of Debian-based systems")
+option(BUILD_WITH_DPKG "enable dpkg-based install for debian and debian derivatives" OFF)
+if(BUILD_WITH_DPKG)
+    find_program(DPKG_PROGRAM dpkg DOC "dpkg program of Debian-based systems")
+endif(BUILD_WITH_DPKG)
 
 # Location of morrowind data files
 if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,12 @@ option(USE_MPG123 "use mpg123 + libsndfile for sound" ON)
 # OS X deployment
 option(OPENMW_OSX_DEPLOYMENT OFF)
 
-option(BUILD_WITH_DPKG "enable dpkg-based install for debian and debian derivatives" OFF)
-if(BUILD_WITH_DPKG)
-    find_program(DPKG_PROGRAM dpkg DOC "dpkg program of Debian-based systems")
-endif(BUILD_WITH_DPKG)
+if(UNIX AND NOT APPLE)
+    option(BUILD_WITH_DPKG "enable dpkg-based install for debian and debian derivatives" OFF)
+    if(BUILD_WITH_DPKG)
+        find_program(DPKG_PROGRAM dpkg DOC "dpkg program of Debian-based systems")
+    endif(BUILD_WITH_DPKG)
+endif(UNIX AND NOT APPLE)
 
 # Location of morrowind data files
 if (APPLE)


### PR DESCRIPTION
The current system automagically chooses between the dpkg-based install method
(for debian-derived distributions) and a "traditional" install and sets
install paths based on whether cmake can find a 'dpkg' executable.

This is not ideal, since dpkg is occasionally installed on linux distributions
unrelated to debian for purposes other than package management. In particular,
Arch and Gentoo carry it in their repositories.

---

I spoke with BrotherBrick and scrawl in irc about this today. BrotherBrick acked this patch.

Making a debian (or -derivative) build with this change applied will require passing `-DBUILD_WITH_DPKG` to cmake.
