### PR TITLE
Fixes #998: Setting the max health should also set the current health

### DIFF
--- a/apps/openmw/mwscript/statsextensions.cpp
+++ b/apps/openmw/mwscript/statsextensions.cpp
@@ -209,6 +209,7 @@ namespace MWScript
                         .getDynamic (mIndex));
 
                     stat.setModified (value, 0);
+                    stat.setCurrent(value);
 
                     MWWorld::Class::get (ptr).getCreatureStats (ptr).setDynamic (mIndex, stat);
                 }


### PR DESCRIPTION
Added setting current value of dynamic stat in OpSetDynamic class.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
