### PR TITLE
Fixes #1006: Many NPCs have 0 skill

### DIFF
--- a/apps/esmtool/record.cpp
+++ b/apps/esmtool/record.cpp
@@ -989,8 +989,7 @@ void Record<ESM::NPC>::print()
         std::cout << "  Faction: " << mData.mFaction << std::endl;
     std::cout << "  Flags: " << npcFlags(mData.mFlags) << std::endl;
 
-    // Seriously?
-    if (mData.mNpdt52.mGold == -10)
+    if (mData.mNpdtType == ESM::NPC::NPC_WITH_AUTOCALCULATED_STATS)
     {
         std::cout << "  Level: " << mData.mNpdt12.mLevel << std::endl;
         std::cout << "  Reputation: " << (int)mData.mNpdt12.mReputation << std::endl;
@@ -1022,7 +1021,7 @@ void Record<ESM::NPC>::print()
         std::cout << "    Luck: " << (int)mData.mNpdt52.mLuck << std::endl;
 
         std::cout << "  Skills:" << std::endl;
-        for (int i = 0; i != 27; i++)
+        for (int i = 0; i != ESM::Skill::Length; i++)
             std::cout << "    " << skillLabel(i) << ": "
                       << (int)((unsigned char)mData.mNpdt52.mSkills[i]) << std::endl;
 

--- a/apps/openmw/mwmechanics/npcstats.cpp
+++ b/apps/openmw/mwmechanics/npcstats.cpp
@@ -86,7 +86,7 @@ void MWMechanics::NpcStats::setMovementFlag (Flag flag, bool state)
 
 const MWMechanics::Stat<float>& MWMechanics::NpcStats::getSkill (int index) const
 {
-    if (index<0 || index>=27)
+    if (index<0 || index>=ESM::Skill::Length)
         throw std::runtime_error ("skill index out of range");
 
     return (!mIsWerewolf ? mSkill[index] : mWerewolfSkill[index]);
@@ -94,7 +94,7 @@ const MWMechanics::Stat<float>& MWMechanics::NpcStats::getSkill (int index) cons
 
 MWMechanics::Stat<float>& MWMechanics::NpcStats::getSkill (int index)
 {
-    if (index<0 || index>=27)
+    if (index<0 || index>=ESM::Skill::Length)
         throw std::runtime_error ("skill index out of range");
 
     return (!mIsWerewolf ? mSkill[index] : mWerewolfSkill[index]);

--- a/components/esm/loadnpc.cpp
+++ b/components/esm/loadnpc.cpp
@@ -10,7 +10,7 @@ namespace ESM
 
 void NPC::load(ESMReader &esm)
 {
-    mNpdt52.mGold = -10;
+    //mNpdt52.mGold = -10;
 
     mPersistent = esm.getRecordFlags() & 0x0400;
 
@@ -29,12 +29,12 @@ void NPC::load(ESMReader &esm)
     esm.getSubHeader();
     if (esm.getSubSize() == 52)
     {
-        mNpdtType = 52;
+        mNpdtType = NPC_DEFAULT;
         esm.getExact(&mNpdt52, 52);
     }
     else if (esm.getSubSize() == 12)
     {
-        mNpdtType = 12;
+        mNpdtType = NPC_WITH_AUTOCALCULATED_STATS;
         esm.getExact(&mNpdt12, 12);
     }
     else
@@ -76,9 +76,9 @@ void NPC::save(ESMWriter &esm) const
     esm.writeHNCString("KNAM", mHair);
     esm.writeHNOCString("SCRI", mScript);
 
-    if (mNpdtType == 52)
+    if (mNpdtType == NPC_DEFAULT)
         esm.writeHNT("NPDT", mNpdt52, 52);
-    else if (mNpdtType == 12)
+    else if (mNpdtType == NPC_WITH_AUTOCALCULATED_STATS)
         esm.writeHNT("NPDT", mNpdt12, 12);
 
     esm.writeHNT("FLAG", mFlags);
@@ -114,7 +114,7 @@ void NPC::save(ESMWriter &esm) const
         mNpdt52.mLevel = 0;
         mNpdt52.mStrength = mNpdt52.mIntelligence = mNpdt52.mWillpower = mNpdt52.mAgility =
             mNpdt52.mSpeed = mNpdt52.mEndurance = mNpdt52.mPersonality = mNpdt52.mLuck = 0;
-        for (int i=0; i<27; ++i) mNpdt52.mSkills[i] = 0;
+        for (int i=0; i< Skill::Length; ++i) mNpdt52.mSkills[i] = 0;
         mNpdt52.mReputation = 0;
         mNpdt52.mHealth = mNpdt52.mMana = mNpdt52.mFatigue = 0;
         mNpdt52.mDisposition = 0;

--- a/components/esm/loadnpc.hpp
+++ b/components/esm/loadnpc.hpp
@@ -8,6 +8,7 @@
 #include "loadcont.hpp"
 #include "aipackage.hpp"
 #include "spelllist.hpp"
+#include "loadskil.hpp"
 
 namespace ESM {
 
@@ -58,6 +59,12 @@ struct NPC
       Metal     = 0x0800  // Metal blood effect (golden?)
     };
 
+  enum NpcType
+  {
+    NPC_WITH_AUTOCALCULATED_STATS = 12,
+    NPC_DEFAULT = 52
+  };
+
     #pragma pack(push)
     #pragma pack(1)
 
@@ -73,7 +80,7 @@ struct NPC
              mPersonality,
              mLuck;
 
-        char mSkills[27];
+        char mSkills[Skill::Length];
         char mReputation;
         short mHealth, mMana, mFatigue;
         char mDisposition, mFactionID, mRank;


### PR DESCRIPTION
Added calculation of skill values for NPC with mNpdtType
set to NPC_WITH_AUTOCALCULATED_STATS (their NPDT is 12).

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
