### PR TITLE
bug fix http://bugs.openmw.org/issues/428 - player's death

### DIFF
--- a/apps/openmw/mwbase/windowmanager.hpp
+++ b/apps/openmw/mwbase/windowmanager.hpp
@@ -202,6 +202,8 @@ namespace MWBase
             virtual void setSpellVisibility(bool visible) = 0;
             virtual void setSneakVisibility(bool visible) = 0;
 
+            void virtual setMainMenuNoReturn(bool noreturn) = 0;
+
             virtual void activateQuickKey  (int index) = 0;
 
             virtual void setSelectedSpell(const std::string& spellId, int successChancePercent) = 0;

--- a/apps/openmw/mwbase/world.hpp
+++ b/apps/openmw/mwbase/world.hpp
@@ -40,6 +40,7 @@ namespace ESM
 
 namespace MWRender
 {
+    class Camera;
     class ExternalRendering;
     class Animation;
 }
@@ -114,6 +115,8 @@ namespace MWBase
             virtual const MWWorld::Fallback *getFallback () const = 0;
 
             virtual MWWorld::Player& getPlayer() = 0;
+
+            virtual MWRender::Camera* getCamera() const = 0;
 
             virtual const MWWorld::ESMStore& getStore() const = 0;
 

--- a/apps/openmw/mwgui/mainmenu.cpp
+++ b/apps/openmw/mwgui/mainmenu.cpp
@@ -17,6 +17,7 @@ namespace MWGui
     MainMenu::MainMenu(int w, int h)
         : OEngine::GUI::Layout("openmw_mainmenu.layout")
         , mButtonBox(0)
+        , mNoReturn(false)
     {
         onResChange(w,h);
     }
@@ -33,7 +34,8 @@ namespace MWGui
         int curH = 0;
 
         std::vector<std::string> buttons;
-        buttons.push_back("return");
+        if(!mNoReturn)
+            buttons.push_back("return");
         buttons.push_back("newgame");
         //buttons.push_back("loadgame");
         //buttons.push_back("savegame");
@@ -66,6 +68,15 @@ namespace MWGui
         }
 
         mButtonBox->setCoord (w/2 - maxwidth/2, h/2 - curH/2, maxwidth, curH);
+    }
+
+    void MainMenu::setNoReturn(bool bNoReturn)
+    {
+        if (mNoReturn != bNoReturn)
+        {
+            mNoReturn = bNoReturn;
+            onResChange( Settings::Manager::getInt("resolution x", "Video"), Settings::Manager::getInt("resolution y", "Video") );
+        }
     }
 
     void MainMenu::onButtonClicked(MyGUI::Widget *sender)

--- a/apps/openmw/mwgui/mainmenu.hpp
+++ b/apps/openmw/mwgui/mainmenu.hpp
@@ -12,8 +12,12 @@ namespace MWGui
 
         void onResChange(int w, int h);
 
+        void setNoReturn(bool bNoReturn);
+
     private:
         MyGUI::Widget* mButtonBox;
+
+        bool mNoReturn;
 
         std::map<std::string, MWGui::ImageButton*> mButtons;
 

--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -880,6 +880,11 @@ namespace MWGui
         mHud->setSneakVisible(visible);
     }
 
+    void WindowManager::setMainMenuNoReturn(bool noreturn)
+    {
+        mMenu->setNoReturn(noreturn);
+    }
+
     void WindowManager::setDragDrop(bool dragDrop)
     {
         mToolTips->setEnabled(!dragDrop);

--- a/apps/openmw/mwgui/windowmanagerimp.hpp
+++ b/apps/openmw/mwgui/windowmanagerimp.hpp
@@ -198,6 +198,9 @@ namespace MWGui
     virtual void setSpellVisibility(bool visible);
     virtual void setSneakVisibility(bool visible);
 
+    //disables 'return' button in the main menu (used when player is dead)
+    void virtual setMainMenuNoReturn(bool noreturn);
+
     virtual void activateQuickKey  (int index);
 
     virtual void setSelectedSpell(const std::string& spellId, int successChancePercent);

--- a/apps/openmw/mwinput/inputmanagerimp.cpp
+++ b/apps/openmw/mwinput/inputmanagerimp.cpp
@@ -367,24 +367,27 @@ namespace MWInput
                 }
             }
 
-            if (mControlSwitch["playerviewswitch"]) {
-
-                // work around preview mode toggle when pressing Alt+Tab
-                if (actionIsActive(A_TogglePOV) && !mInputManager->isModifierHeld(SDL_Keymod(KMOD_ALT))) {
-                    if (mPreviewPOVDelay <= 0.5 &&
-                        (mPreviewPOVDelay += dt) > 0.5)
-                    {
-                        mPreviewPOVDelay = 1.f;
-                        MWBase::Environment::get().getWorld()->togglePreviewMode(true);
+            MWWorld::Ptr player = MWBase::Environment::get().getWorld ()->getPlayer().getPlayer();
+            if ( !player.getClass().getCreatureStats(player).isDead() ) {
+                if (mControlSwitch["playerviewswitch"]) {
+                    // work around preview mode toggle when pressing Alt+Tab
+                    if (actionIsActive(A_TogglePOV) && !mInputManager->isModifierHeld(SDL_Keymod(KMOD_ALT))) {
+                    
+                        if (mPreviewPOVDelay <= 0.5 &&
+                            (mPreviewPOVDelay += dt) > 0.5)
+                        {
+                            mPreviewPOVDelay = 1.f;
+                            MWBase::Environment::get().getWorld()->togglePreviewMode(true);
+                        }
+                    } else {
+                        if (mPreviewPOVDelay > 0.5) {
+                            //disable preview mode
+                            MWBase::Environment::get().getWorld()->togglePreviewMode(false);
+                        } else if (mPreviewPOVDelay > 0.f) {
+                            MWBase::Environment::get().getWorld()->togglePOV();
+                        }
+                        mPreviewPOVDelay = 0.f;
                     }
-                } else {
-                    if (mPreviewPOVDelay > 0.5) {
-                        //disable preview mode
-                        MWBase::Environment::get().getWorld()->togglePreviewMode(false);
-                    } else if (mPreviewPOVDelay > 0.f) {
-                        MWBase::Environment::get().getWorld()->togglePOV();
-                    }
-                    mPreviewPOVDelay = 0.f;
                 }
             }
         }

--- a/apps/openmw/mwmechanics/actors.cpp
+++ b/apps/openmw/mwmechanics/actors.cpp
@@ -570,15 +570,13 @@ namespace MWMechanics
                     continue;
                 }
 
-                if(iter->second->isDead())
-                    continue;
+                if (iter->second->kill())
+                {
+                    ++mDeathCount[cls.getId(iter->first)];
 
-                iter->second->kill();
-
-                ++mDeathCount[cls.getId(iter->first)];
-
-                if(cls.isEssential(iter->first))
-                    MWBase::Environment::get().getWindowManager()->messageBox("#{sKilledEssential}");
+                    if(cls.isEssential(iter->first))
+                        MWBase::Environment::get().getWindowManager()->messageBox("#{sKilledEssential}");
+                }
             }
         }
 

--- a/apps/openmw/mwmechanics/character.hpp
+++ b/apps/openmw/mwmechanics/character.hpp
@@ -190,7 +190,7 @@ public:
     void skipAnim();
     bool isAnimPlaying(const std::string &groupName);
 
-    void kill();
+    bool kill();
     void resurrect();
     bool isDead() const
     { return mDeathState != CharState_None; }

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -211,6 +211,11 @@ MWRender::SkyManager* RenderingManager::getSkyManager()
     return mSkyManager;
 }
 
+MWRender::Camera* RenderingManager::getCamera() const
+{
+    return mCamera;
+}
+
 MWRender::Objects& RenderingManager::getObjects(){
     return *mObjects;
 }

--- a/apps/openmw/mwrender/renderingmanager.hpp
+++ b/apps/openmw/mwrender/renderingmanager.hpp
@@ -98,6 +98,8 @@ public:
     SkyManager* getSkyManager();
     Compositors* getCompositors();
 
+    MWRender::Camera* getCamera() const;
+
     void toggleLight();
     bool toggleRenderMode(int mode);
 

--- a/apps/openmw/mwworld/worldimp.cpp
+++ b/apps/openmw/mwworld/worldimp.cpp
@@ -312,6 +312,8 @@ namespace MWWorld
         mWeatherManager = new MWWorld::WeatherManager(mRendering,&mFallback);
 
         MWBase::Environment::get().getScriptManager()->resetGlobalScripts();
+
+        MWBase::Environment::get().getWindowManager()->setMainMenuNoReturn(false);
     }
 
 
@@ -402,6 +404,11 @@ namespace MWWorld
     {
         return *mPlayer;
     }
+
+    MWRender::Camera* World::getCamera() const
+	{
+        return mRendering->getCamera(); 
+	}
 
     const MWWorld::ESMStore& World::getStore() const
     {
@@ -1304,7 +1311,7 @@ namespace MWWorld
         // inform the GUI about focused object
         MWWorld::Ptr object = getFacedObject ();
 
-        MWBase::Environment::get().getWindowManager()->setFocusObject(object);
+        MWBase::Environment::get().getWindowManager()->setFocusObject(object);  
 
         // retrieve object dimensions so we know where to place the floating label
         if (!object.isEmpty ())

--- a/apps/openmw/mwworld/worldimp.hpp
+++ b/apps/openmw/mwworld/worldimp.hpp
@@ -187,6 +187,8 @@ namespace MWWorld
 
             virtual Player& getPlayer();
 
+            virtual MWRender::Camera* getCamera() const;
+
             virtual const MWWorld::ESMStore& getStore() const;
 
             virtual std::vector<ESM::ESMReader>& getEsmReader();


### PR DESCRIPTION
Appropriate handling of player death: 1)turn POV on or leave POV/preview mode 2)and don't allow to toggle view in InputManager::update (or animation will be played again). 
Main handling is in MWMechanics::CharacterController::kill().
Functions:
Disable return option in main menu func: MWGui::MainMenu -> MWGui::WindowManager
Reenables 'return' at World::startNewGame().
For checking if camera is in first person, getCamera() func: MWRender::RenderingManager->MWWorld::World
