### PR TITLE
Fixes #1042: TES3 header data wrong encoding

### DIFF
--- a/components/esm/loadtes3.cpp
+++ b/components/esm/loadtes3.cpp
@@ -19,7 +19,15 @@ void ESM::Header::blank()
 
 void ESM::Header::load (ESMReader &esm)
 {
-    esm.getHNT (mData, "HEDR", 300);
+    if (esm.isNextSub("HEDR"))
+    {
+      esm.getSubHeader();
+      esm.getT(mData.version);
+      esm.getT(mData.type);
+      mData.author.assign(esm.getString(sizeof(mData.author.name)));
+      mData.desc.assign(esm.getString(sizeof(mData.desc.name)));
+      esm.getT(mData.records);
+    }
 
     if (esm.isNextSub ("FORM"))
     {


### PR DESCRIPTION
Changed loading of HEDR structure from all-in-once to field-by-field
so author and description could be converted to UTF-8.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
