### PR TITLE
Fix warning about uninitialized variable inside stream.peak():

### DIFF
--- a/components/misc/utf8stream.hpp
+++ b/components/misc/utf8stream.hpp
@@ -14,12 +14,12 @@ public:
     static UnicodeChar sBadChar () { return UnicodeChar (0xFFFFFFFF); }
 
     Utf8Stream (Point begin, Point end) :
-        cur (begin), nxt (begin), end (end)
+        cur (begin), nxt (begin), end (end), val(Utf8Stream::sBadChar())
     {
     }
 
     Utf8Stream (std::pair <Point, Point> range) :
-        cur (range.first), nxt (range.first), end (range.second)
+        cur (range.first), nxt (range.first), end (range.second), val(Utf8Stream::sBadChar())
     {
     }
 


### PR DESCRIPTION
Fix warning about uninitialized variable inside stream.peak():

openmw/mwgui/bookpage.cpp:394:13: warning: ‘_((void_)& stream +24)’ may be used uninitialized in this function [-Wmaybe-uninitialized]

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
