### PR TITLE
Don't try to set a cursor before one exists

### DIFF
--- a/apps/openmw/mwgui/windowmanagerimp.cpp
+++ b/apps/openmw/mwgui/windowmanagerimp.cpp
@@ -174,10 +174,10 @@ namespace MWGui
 
         MyGUI::InputManager::getInstance().eventChangeKeyFocus += MyGUI::newDelegate(this, &WindowManager::onKeyFocusChanged);
 
-        mCursorManager->setEnabled(true);
-
         onCursorChange(MyGUI::PointerManager::getInstance().getDefaultPointer());
         SDL_ShowCursor(false);
+
+        mCursorManager->setEnabled(true);
 
         // hide mygui's pointer
         MyGUI::PointerManager::getInstance().setVisible(false);


### PR DESCRIPTION
This would cause the Windows builds (Don't know about the other ones) to crash the moment the line is executed if no cursor exists to enable.
