### PR TITLE
Bug #1074: Inventory paperdoll obscures armour rating

### DIFF
--- a/apps/openmw/mwrender/characterpreview.cpp
+++ b/apps/openmw/mwrender/characterpreview.cpp
@@ -128,7 +128,7 @@ namespace MWRender
 
 
     InventoryPreview::InventoryPreview(MWWorld::Ptr character)
-        : CharacterPreview(character, 512, 1024, "CharacterPreview", Ogre::Vector3(0, 65, -180), Ogre::Vector3(0,65,0))
+        : CharacterPreview(character, 512, 1024, "CharacterPreview", Ogre::Vector3(0, 62, -200), Ogre::Vector3(0, 62, 0))
         , mSelectionBuffer(NULL)
     {
     }


### PR DESCRIPTION
Changed size of inventory paperdoll.

Signed-off-by: Lukasz Gromanowski lgromanowski@gmail.com
