### PR TITLE
Few fixes to get workable builds on VS2010.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,9 @@ if (WIN32)
     set(Boost_USE_STATIC_LIBS   ON)
     set(PLATFORM_INCLUDE_DIR "platform")
     add_definitions(-DBOOST_ALL_NO_LIB)
+
+    # Suppress WinMain(), provided by SDL
+    add_definitions(-DSDL_MAIN_HANDLED)
 else (WIN32)
     set(PLATFORM_INCLUDE_DIR "")
     find_path (UUID_INCLUDE_DIR uuid/uuid.h)

--- a/apps/openmw/main.cpp
+++ b/apps/openmw/main.cpp
@@ -11,6 +11,7 @@
 #include <boost/iostreams/stream_buffer.hpp>
 
 // For OutputDebugString
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 // makes __argc and __argv available on windows
 #include <cstdlib>

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -555,6 +555,11 @@ MWWorld::ContainerStoreIterator::ContainerStoreIterator (ContainerStore *contain
 MWWorld::ContainerStoreIterator::ContainerStoreIterator (ContainerStore *container, MWWorld::CellRefList<ESM::Weapon>::List::iterator iterator)
     : mType(MWWorld::ContainerStore::Type_Weapon), mMask(MWWorld::ContainerStore::Type_All), mContainer(container), mWeapon(iterator){}
 
+MWWorld::ContainerStoreIterator::ContainerStoreIterator( const ContainerStoreIterator& src )
+{
+	copy(src);
+}
+
 void MWWorld::ContainerStoreIterator::incType()
 {
     if (mType==0)
@@ -805,6 +810,41 @@ int MWWorld::ContainerStoreIterator::getType() const
 const MWWorld::ContainerStore *MWWorld::ContainerStoreIterator::getContainerStore() const
 {
     return mContainer;
+}
+
+void MWWorld::ContainerStoreIterator::copy(const ContainerStoreIterator& src)
+{
+	mType = src.mType;
+	mMask = src.mMask;
+	mContainer = src.mContainer;
+	mPtr = src.mPtr;
+
+	switch (mType)
+	{
+		case MWWorld::ContainerStore::Type_Potion: mPotion = src.mPotion; break;
+		case MWWorld::ContainerStore::Type_Apparatus: mApparatus = src.mApparatus; break;
+		case MWWorld::ContainerStore::Type_Armor: mArmor = src.mArmor; break;
+		case MWWorld::ContainerStore::Type_Book: mBook = src.mBook; break;
+		case MWWorld::ContainerStore::Type_Clothing: mClothing = src.mClothing; break;
+		case MWWorld::ContainerStore::Type_Ingredient: mIngredient = src.mIngredient; break;
+		case MWWorld::ContainerStore::Type_Light: mLight = src.mLight; break;
+		case MWWorld::ContainerStore::Type_Lockpick: mLockpick = src.mLockpick; break;
+		case MWWorld::ContainerStore::Type_Miscellaneous: mMiscellaneous = src.mMiscellaneous; break;
+		case MWWorld::ContainerStore::Type_Probe: mProbe = src.mProbe; break;
+		case MWWorld::ContainerStore::Type_Repair: mRepair = src.mRepair; break;
+		case MWWorld::ContainerStore::Type_Weapon: mWeapon = src.mWeapon; break;
+		case -1: break;
+		default: assert(0);
+	}
+}
+
+MWWorld::ContainerStoreIterator& MWWorld::ContainerStoreIterator::operator=( const ContainerStoreIterator& rhs )
+{
+	if (this!=&rhs)
+	{
+		copy(rhs);
+	}
+	return *this;
 }
 
 bool MWWorld::operator== (const ContainerStoreIterator& left, const ContainerStoreIterator& right)

--- a/apps/openmw/mwworld/containerstore.cpp
+++ b/apps/openmw/mwworld/containerstore.cpp
@@ -557,7 +557,7 @@ MWWorld::ContainerStoreIterator::ContainerStoreIterator (ContainerStore *contain
 
 MWWorld::ContainerStoreIterator::ContainerStoreIterator( const ContainerStoreIterator& src )
 {
-	copy(src);
+    copy(src);
 }
 
 void MWWorld::ContainerStoreIterator::incType()
@@ -814,37 +814,37 @@ const MWWorld::ContainerStore *MWWorld::ContainerStoreIterator::getContainerStor
 
 void MWWorld::ContainerStoreIterator::copy(const ContainerStoreIterator& src)
 {
-	mType = src.mType;
-	mMask = src.mMask;
-	mContainer = src.mContainer;
-	mPtr = src.mPtr;
+    mType = src.mType;
+    mMask = src.mMask;
+    mContainer = src.mContainer;
+    mPtr = src.mPtr;
 
-	switch (mType)
-	{
-		case MWWorld::ContainerStore::Type_Potion: mPotion = src.mPotion; break;
-		case MWWorld::ContainerStore::Type_Apparatus: mApparatus = src.mApparatus; break;
-		case MWWorld::ContainerStore::Type_Armor: mArmor = src.mArmor; break;
-		case MWWorld::ContainerStore::Type_Book: mBook = src.mBook; break;
-		case MWWorld::ContainerStore::Type_Clothing: mClothing = src.mClothing; break;
-		case MWWorld::ContainerStore::Type_Ingredient: mIngredient = src.mIngredient; break;
-		case MWWorld::ContainerStore::Type_Light: mLight = src.mLight; break;
-		case MWWorld::ContainerStore::Type_Lockpick: mLockpick = src.mLockpick; break;
-		case MWWorld::ContainerStore::Type_Miscellaneous: mMiscellaneous = src.mMiscellaneous; break;
-		case MWWorld::ContainerStore::Type_Probe: mProbe = src.mProbe; break;
-		case MWWorld::ContainerStore::Type_Repair: mRepair = src.mRepair; break;
-		case MWWorld::ContainerStore::Type_Weapon: mWeapon = src.mWeapon; break;
-		case -1: break;
-		default: assert(0);
-	}
+    switch (mType)
+    {
+        case MWWorld::ContainerStore::Type_Potion: mPotion = src.mPotion; break;
+        case MWWorld::ContainerStore::Type_Apparatus: mApparatus = src.mApparatus; break;
+        case MWWorld::ContainerStore::Type_Armor: mArmor = src.mArmor; break;
+        case MWWorld::ContainerStore::Type_Book: mBook = src.mBook; break;
+        case MWWorld::ContainerStore::Type_Clothing: mClothing = src.mClothing; break;
+        case MWWorld::ContainerStore::Type_Ingredient: mIngredient = src.mIngredient; break;
+        case MWWorld::ContainerStore::Type_Light: mLight = src.mLight; break;
+        case MWWorld::ContainerStore::Type_Lockpick: mLockpick = src.mLockpick; break;
+        case MWWorld::ContainerStore::Type_Miscellaneous: mMiscellaneous = src.mMiscellaneous; break;
+        case MWWorld::ContainerStore::Type_Probe: mProbe = src.mProbe; break;
+        case MWWorld::ContainerStore::Type_Repair: mRepair = src.mRepair; break;
+        case MWWorld::ContainerStore::Type_Weapon: mWeapon = src.mWeapon; break;
+        case -1: break;
+        default: assert(0);
+    }
 }
 
 MWWorld::ContainerStoreIterator& MWWorld::ContainerStoreIterator::operator=( const ContainerStoreIterator& rhs )
 {
-	if (this!=&rhs)
-	{
-		copy(rhs);
-	}
-	return *this;
+    if (this!=&rhs)
+    {
+        copy(rhs);
+    }
+    return *this;
 }
 
 bool MWWorld::operator== (const ContainerStoreIterator& left, const ContainerStoreIterator& right)

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -143,10 +143,6 @@ namespace MWWorld
             MWWorld::CellRefList<ESM::Repair>::List::iterator mRepair;
             MWWorld::CellRefList<ESM::Weapon>::List::iterator mWeapon;
 
-		public:
-
-			ContainerStoreIterator(const ContainerStoreIterator& src);
-
         private:
 
             ContainerStoreIterator (ContainerStore *container);
@@ -187,6 +183,8 @@ namespace MWWorld
 
         public:
 
+            ContainerStoreIterator(const ContainerStoreIterator& src);
+
             Ptr *operator->() const;
 
             Ptr operator*() const;
@@ -195,7 +193,7 @@ namespace MWWorld
 
             ContainerStoreIterator operator++ (int);
 
-			ContainerStoreIterator& operator= (const ContainerStoreIterator& rhs);			
+            ContainerStoreIterator& operator= (const ContainerStoreIterator& rhs);			
 
             bool isEqual (const ContainerStoreIterator& iter) const;
 

--- a/apps/openmw/mwworld/containerstore.hpp
+++ b/apps/openmw/mwworld/containerstore.hpp
@@ -143,6 +143,10 @@ namespace MWWorld
             MWWorld::CellRefList<ESM::Repair>::List::iterator mRepair;
             MWWorld::CellRefList<ESM::Weapon>::List::iterator mWeapon;
 
+		public:
+
+			ContainerStoreIterator(const ContainerStoreIterator& src);
+
         private:
 
             ContainerStoreIterator (ContainerStore *container);
@@ -164,6 +168,8 @@ namespace MWWorld
             ContainerStoreIterator (ContainerStore *container, MWWorld::CellRefList<ESM::Probe>::List::iterator);
             ContainerStoreIterator (ContainerStore *container, MWWorld::CellRefList<ESM::Repair>::List::iterator);
             ContainerStoreIterator (ContainerStore *container, MWWorld::CellRefList<ESM::Weapon>::List::iterator);
+
+			void copy (const ContainerStoreIterator& src);
 
             void incType();
 
@@ -188,6 +194,8 @@ namespace MWWorld
             ContainerStoreIterator& operator++();
 
             ContainerStoreIterator operator++ (int);
+
+			ContainerStoreIterator& operator= (const ContainerStoreIterator& rhs);			
 
             bool isEqual (const ContainerStoreIterator& iter) const;
 


### PR DESCRIPTION
- Fix for possible undefined behaviour of assignment operator ( discussion: https://forum.openmw.org/viewtopic.php?f=8&t=1975 );
- WIN32_LEAN_AND_MEAN definition is added to drop useless (for OMW) stuff from Windows.h (like Winsock, OLE headers, etc.);
- I received link-time conflict between OMW and SDL / double definition of WinMain() /, so third commit is about to fix that by defining SDL_MAIN_HANDLED.

By applying patches, described above, Windows user should get fully workable builds on all existent configurations.
