### PR TITLE
appropriate camera vanity<>preview mode switch + hit recoils fix

### DIFF
--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -179,6 +179,12 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
                     mHitState = CharState_Hit;
                     int iHit = rand() % (sHitListSize-1);
                     mCurrentHit = sHitList[iHit];
+                    if(mPtr.getRefData().getHandle()=="player" && !mAnimation->hasAnimation(mCurrentHit))
+                    {
+                        //only 4 different hit animations if player is in 1st person
+                        int iHit = rand() % (sHitListSize-3);
+                        mCurrentHit = sHitList[iHit];
+                    }
                     mAnimation->play(mCurrentHit, Priority_Hit, MWRender::Animation::Group_All, true, 1, "start", "stop", 0.0f, 0);
                 }
             }

--- a/apps/openmw/mwmechanics/character.cpp
+++ b/apps/openmw/mwmechanics/character.cpp
@@ -181,7 +181,7 @@ void CharacterController::refreshCurrentAnims(CharacterState idle, CharacterStat
                     mCurrentHit = sHitList[iHit];
                     if(mPtr.getRefData().getHandle()=="player" && !mAnimation->hasAnimation(mCurrentHit))
                     {
-                        //only 4 different hit animations if player is in 1st person
+                        //only 3 different hit animations if player is in 1st person
                         int iHit = rand() % (sHitListSize-3);
                         mCurrentHit = sHitList[iHit];
                     }
@@ -489,7 +489,7 @@ bool CharacterController::updateNpcState(bool onground, bool inwater, bool isrun
     const bool isWerewolf = stats.isWerewolf();
 
     bool forcestateupdate = false;
-    if(weaptype != mWeaponType)
+    if(weaptype != mWeaponType && mHitState != CharState_KnockDown)
     {
         forcestateupdate = true;
 

--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -387,7 +387,6 @@ Ogre::Node *Animation::getNode(const std::string &name)
     return NULL;
 }
 
-
 NifOgre::TextKeyMap::const_iterator Animation::findGroupStart(const NifOgre::TextKeyMap &keys, const std::string &groupname)
 {
     NifOgre::TextKeyMap::const_iterator iter(keys.begin());
@@ -1008,14 +1007,16 @@ void Animation::detachObjectFromBone(Ogre::MovableObject *obj)
     mSkelBase->detachObjectFromBone(obj);
 }
 
-bool Animation::isPlaying(Group group) const
+bool Animation::allowSwitchViewMode() const
 {
     for (AnimStateMap::const_iterator stateiter = mStates.begin(); stateiter != mStates.end(); ++stateiter)
     {
-        if(stateiter->second.mGroups == group)
-            return true;
+        if(stateiter->second.mGroups == Group_UpperBody 
+                || (stateiter->first.size()==4 && stateiter->first.find("hit") != std::string::npos)
+                || (stateiter->first.find("knock") != std::string::npos) )
+            return false;
     }
-    return false;
+    return true;
 }
 
 void Animation::addEffect(const std::string &model, int effectId, bool loop, const std::string &bonename, std::string texture)

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -258,7 +258,7 @@ public:
     /** Returns true if the named animation group is playing. */
     bool isPlaying(const std::string &groupname) const;
 
-    bool isPlaying(Group group) const;
+    bool allowSwitchViewMode() const;
 
     /** Gets info about the given animation group.
      * \param groupname Animation group to check.

--- a/apps/openmw/mwrender/animation.hpp
+++ b/apps/openmw/mwrender/animation.hpp
@@ -258,6 +258,7 @@ public:
     /** Returns true if the named animation group is playing. */
     bool isPlaying(const std::string &groupname) const;
 
+    //Checks if playing any animation which shouldn't be stopped when switching camera view modes
     bool allowSwitchViewMode() const;
 
     /** Gets info about the given animation group.

--- a/apps/openmw/mwrender/camera.cpp
+++ b/apps/openmw/mwrender/camera.cpp
@@ -107,7 +107,7 @@ namespace MWRender
 
     void Camera::update(float duration, bool paused)
     {
-        if (!mAnimation->isPlaying(MWRender::Animation::Group_UpperBody))
+        if (mAnimation->allowSwitchViewMode())
         {
             // Now process the view changes we queued earlier
             if (mVanityToggleQueued)
@@ -144,7 +144,7 @@ namespace MWRender
     {
         // Changing the view will stop all playing animations, so if we are playing
         // anything important, queue the view change for later
-        if (mAnimation->isPlaying(MWRender::Animation::Group_UpperBody))
+        if (!mAnimation->allowSwitchViewMode())
         {
             mViewModeToggleQueued = true;
             return;
@@ -171,7 +171,7 @@ namespace MWRender
     {
         // Changing the view will stop all playing animations, so if we are playing
         // anything important, queue the view change for later
-        if (mAnimation->isPlaying(MWRender::Animation::Group_UpperBody))
+        if (!mPreviewMode)
         {
             mVanityToggleQueued = true;
             return false;
@@ -205,7 +205,7 @@ namespace MWRender
 
     void Camera::togglePreviewMode(bool enable)
     {
-        if (mAnimation->isPlaying(MWRender::Animation::Group_UpperBody))
+        if (mFirstPersonView && !mAnimation->allowSwitchViewMode())
             return;
 
         if(mPreviewMode == enable)
@@ -358,7 +358,7 @@ namespace MWRender
             Ogre::TagPoint *tag = mAnimation->attachObjectToBone("Head", mCamera);
             tag->setInheritOrientation(false);
         }
-        else
+        else 
         {
             mAnimation->setViewMode(NpcAnimation::VM_Normal);
             mCameraNode->attachObject(mCamera);

--- a/apps/openmw/mwrender/npcanimation.cpp
+++ b/apps/openmw/mwrender/npcanimation.cpp
@@ -140,6 +140,9 @@ NpcAnimation::NpcAnimation(const MWWorld::Ptr& ptr, Ogre::SceneNode* node, int v
 void NpcAnimation::setViewMode(NpcAnimation::ViewMode viewMode)
 {
     assert(viewMode != VM_HeadOnly);
+    if(mViewMode == viewMode) 
+        return;
+
     mViewMode = viewMode;
     rebuild();
 }


### PR DESCRIPTION
after this commit you will be able to switch vanity<>preview modes without stopping current animations;
also you won't be able to switch view while in hit recoil/knockdown/knockout state
func Animation::IsPlaying(Group group) was used only in camera.cpp so I modified it and gave more appropriate name
