### PR TITLE
openmw is now available in [community]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -23,8 +23,8 @@ Ubuntu (and most others)
 Download the .deb file and install it in the usual way.
 
 Arch Linux
-There's an OpenMW package available in the AUR Repository:
-http://aur.archlinux.org/packages.php?ID=21419
+There's an OpenMW package available in the [community] Repository:
+https://www.archlinux.org/packages/?sort=&q=openmw
 
 OS X:
 Open DMG file, copy OpenMW folder anywhere, for example in /Applications


### PR DESCRIPTION
OpenMW has been adopted by an Arch Developer and placed in [community] as a pre-compiled package.
The upstream packaged (openmw-git) is still available in the AUR.

See https://forum.openmw.org/viewtopic.php?f=20&t=1995&p=21575#p21575 for more info.
