### PR TITLE
fix variable naming

### DIFF
--- a/apps/openmw/mwrender/objects.cpp
+++ b/apps/openmw/mwrender/objects.cpp
@@ -80,11 +80,11 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh)
     extents *= ptr.getRefData().getBaseNode()->getScale();
     float size = std::max(std::max(extents.x, extents.y), extents.z);
 
-    bool small = (size < Settings::Manager::getInt("small object size", "Viewing distance")) &&
+    bool isSmall = (size < Settings::Manager::getInt("small object size", "Viewing distance")) &&
                  Settings::Manager::getBool("limit small object distance", "Viewing distance");
     // do not fade out doors. that will cause holes and look stupid
     if(ptr.getTypeName().find("Door") != std::string::npos)
-        small = false;
+        isSmall = false;
 
     if (mBounds.find(ptr.getCell()) == mBounds.end())
         mBounds[ptr.getCell()] = Ogre::AxisAlignedBox::BOX_NULL;
@@ -99,7 +99,7 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh)
     {
         Ogre::StaticGeometry* sg = 0;
 
-        if (small)
+        if (isSmall)
         {
             if(mStaticGeometrySmall.find(ptr.getCell()) == mStaticGeometrySmall.end())
             {
@@ -135,7 +135,7 @@ void Objects::insertModel(const MWWorld::Ptr &ptr, const std::string &mesh)
         else
             sg->setRegionDimensions(Ogre::Vector3(1024,1024,1024));
 
-        sg->setVisibilityFlags(small ? RV_StaticsSmall : RV_Statics);
+        sg->setVisibilityFlags(isSmall ? RV_StaticsSmall : RV_Statics);
 
         sg->setCastShadows(true);
 


### PR DESCRIPTION
I was compiling openmw about v0.25 on Windows and there was error with variable `small` (naming collision with macro? - I don't remember), so better to rename it to `isSmall`, and perhaps document it in coding conventions something like "boolean variables and functions returning boolean should start with `is` or `has`, for variables also possible to start with `flag_`".
