### PR TITLE
Win fix

### DIFF
--- a/apps/openmw/mwgui/mapwindow.hpp
+++ b/apps/openmw/mwgui/mapwindow.hpp
@@ -2,6 +2,7 @@
 #define MWGUI_MAPWINDOW_H
 
 #include "windowpinnablebase.hpp"
+#include <cstdint>
 
 namespace MWRender
 {

--- a/apps/openmw/mwworld/livecellref.hpp
+++ b/apps/openmw/mwworld/livecellref.hpp
@@ -9,7 +9,7 @@
 
 namespace ESM
 {
-    class ObjectState;
+    struct ObjectState;
 }
 
 namespace MWWorld

--- a/apps/openmw/mwworld/refdata.hpp
+++ b/apps/openmw/mwworld/refdata.hpp
@@ -14,7 +14,7 @@ namespace ESM
 {
     class Script;
     class CellRef;
-    class ObjectState;
+    struct ObjectState;
 }
 
 namespace MWWorld


### PR DESCRIPTION
I don't get why MSVC is this picky regarding structs and classes, but it refuses to link against `MWWorld::LiveCellRefBase::loadImp` or `MWWorld::LiveCellRefBase::saveImp` without this change.
