### PR TITLE
Versioninfo2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
     - /openmw-.*$/
 before_install:
  - pwd
- - git fetch --tags
  - echo "yes" | sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
  - echo "yes" | sudo apt-add-repository ppa:openmw/openmw
  - sudo apt-get update -qq

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,27 +13,39 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/)
 include(OpenMWMacros)
 
 # Version
+set(OPENMW_VERSION_MAJOR 0)
+set(OPENMW_VERSION_MINOR 29)
+set(OPENMW_VERSION_RELEASE 0)
 
-include(GetGitRevisionDescription)
+set(OPENMW_VERSION "${OPENMW_VERSION_MAJOR}.${OPENMW_VERSION_MINOR}.${OPENMW_VERSION_RELEASE}")
 
-get_git_tag_revision(TAGHASH --tags --max-count=1 "HEAD...")
-get_git_head_revision(REFSPEC COMMITHASH)
-git_describe(VERSION --tags ${TAGHASH})
+if(EXISTS ${PROJECT_SOURCE_DIR}/.git)
+    find_package(Git)
 
-string(REGEX MATCH "^openmw-[^0-9]*[0-9]+\\.[0-9]+\\.[0-9]+.*" MATCH "${VERSION}")
-if (MATCH)
-    string(REGEX REPLACE "^openmw-([0-9]+)\\..*" "\\1" OPENMW_VERSION_MAJOR "${VERSION}")
-    string(REGEX REPLACE "^openmw-[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_MINOR "${VERSION}")
-    string(REGEX REPLACE "^openmw-[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_RELEASE "${VERSION}")
+    if(GIT_FOUND)
+        include(GetGitRevisionDescription)
+        get_git_tag_revision(TAGHASH --tags --max-count=1)
+        get_git_head_revision(REFSPEC COMMITHASH)
+        git_describe(VERSION --tags ${TAGHASH})
 
-    set(OPENMW_VERSION "${OPENMW_VERSION_MAJOR}.${OPENMW_VERSION_MINOR}.${OPENMW_VERSION_RELEASE}")
-    set(OPENMW_VERSION_COMMITHASH "${COMMITHASH}")
-    set(OPENMW_VERSION_TAGHASH "${TAGHASH}")
+        string(REGEX MATCH "^openmw-[^0-9]*[0-9]+\\.[0-9]+\\.[0-9]+.*" MATCH "${VERSION}")
+        if(MATCH)
+            string(REGEX REPLACE "^openmw-([0-9]+)\\..*" "\\1" OPENMW_VERSION_MAJOR "${VERSION}")
+            string(REGEX REPLACE "^openmw-[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_MINOR "${VERSION}")
+            string(REGEX REPLACE "^openmw-[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_RELEASE "${VERSION}")
 
-    message(STATUS "Configuring OpenMW ${OPENMW_VERSION}...")
-else (MATCH)
-    message(FATAL_ERROR "Failed to get valid version information from Git")
-endif (MATCH)
+            set(OPENMW_VERSION "${OPENMW_VERSION_MAJOR}.${OPENMW_VERSION_MINOR}.${OPENMW_VERSION_RELEASE}")
+            set(OPENMW_VERSION_COMMITHASH "${COMMITHASH}")
+            set(OPENMW_VERSION_TAGHASH "${TAGHASH}")
+
+            message(STATUS "Configuring OpenMW ${OPENMW_VERSION}...")
+        else(MATCH)
+            message(WARNING "Failed to get valid version information from Git")
+        endif(MATCH)
+    else(GIT_FOUND)
+        message(WARNING "Git executable not found")
+    endif(GIT_FOUND)
+endif(EXISTS ${PROJECT_SOURCE_DIR}/.git)
 
 # doxygen main page
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,46 +6,54 @@ if (APPLE)
     set(APP_BUNDLE_DIR "${OpenMW_BINARY_DIR}/${APP_BUNDLE_NAME}")
 endif (APPLE)
 
-# Macros
-
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/)
 
-include(OpenMWMacros)
-
 # Version
+message(STATUS "Configuring OpenMW...")
+
 set(OPENMW_VERSION_MAJOR 0)
 set(OPENMW_VERSION_MINOR 29)
 set(OPENMW_VERSION_RELEASE 0)
 
+set(OPENMW_VERSION_COMMITHASH "")
+set(OPENMW_VERSION_TAGHASH "")
+
 set(OPENMW_VERSION "${OPENMW_VERSION_MAJOR}.${OPENMW_VERSION_MINOR}.${OPENMW_VERSION_RELEASE}")
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/.git)
-    find_package(Git)
+    if(NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/shallow)
+        find_package(Git)
 
-    if(GIT_FOUND)
-        include(GetGitRevisionDescription)
-        get_git_tag_revision(TAGHASH --tags --max-count=1)
-        get_git_head_revision(REFSPEC COMMITHASH)
-        git_describe(VERSION --tags ${TAGHASH})
+        if(GIT_FOUND)
+            include(GetGitRevisionDescription)
+            get_git_tag_revision(TAGHASH --tags --max-count=1)
+            get_git_head_revision(REFSPEC COMMITHASH)
+            git_describe(VERSION --tags ${TAGHASH})
 
-        string(REGEX MATCH "^openmw-[^0-9]*[0-9]+\\.[0-9]+\\.[0-9]+.*" MATCH "${VERSION}")
-        if(MATCH)
-            string(REGEX REPLACE "^openmw-([0-9]+)\\..*" "\\1" OPENMW_VERSION_MAJOR "${VERSION}")
-            string(REGEX REPLACE "^openmw-[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_MINOR "${VERSION}")
-            string(REGEX REPLACE "^openmw-[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_RELEASE "${VERSION}")
+            string(REGEX MATCH "^openmw-[^0-9]*[0-9]+\\.[0-9]+\\.[0-9]+.*" MATCH "${VERSION}")
+            if(MATCH)
+                string(REGEX REPLACE "^openmw-([0-9]+)\\..*" "\\1" OPENMW_VERSION_MAJOR "${VERSION}")
+                string(REGEX REPLACE "^openmw-[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_MINOR "${VERSION}")
+                string(REGEX REPLACE "^openmw-[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_RELEASE "${VERSION}")
 
-            set(OPENMW_VERSION "${OPENMW_VERSION_MAJOR}.${OPENMW_VERSION_MINOR}.${OPENMW_VERSION_RELEASE}")
-            set(OPENMW_VERSION_COMMITHASH "${COMMITHASH}")
-            set(OPENMW_VERSION_TAGHASH "${TAGHASH}")
+                set(OPENMW_VERSION "${OPENMW_VERSION_MAJOR}.${OPENMW_VERSION_MINOR}.${OPENMW_VERSION_RELEASE}")
+                set(OPENMW_VERSION_COMMITHASH "${COMMITHASH}")
+                set(OPENMW_VERSION_TAGHASH "${TAGHASH}")
 
-            message(STATUS "Configuring OpenMW ${OPENMW_VERSION}...")
-        else(MATCH)
-            message(WARNING "Failed to get valid version information from Git")
-        endif(MATCH)
-    else(GIT_FOUND)
-        message(WARNING "Git executable not found")
-    endif(GIT_FOUND)
+                message(STATUS "OpenMW version ${OPENMW_VERSION}")
+            else(MATCH)
+                message(WARNING "Failed to get valid version information from Git")
+            endif(MATCH)
+        else(GIT_FOUND)
+            message(WARNING "Git executable not found")
+        endif(GIT_FOUND)
+    else(NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/shallow)
+        message(STATUS "Shallow Git clone detected, not attempting to retrieve version info")
+    endif(NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/shallow)
 endif(EXISTS ${PROJECT_SOURCE_DIR}/.git)
+
+# Macros
+include(OpenMWMacros)
 
 # doxygen main page
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/)
 message(STATUS "Configuring OpenMW...")
 
 set(OPENMW_VERSION_MAJOR 0)
-set(OPENMW_VERSION_MINOR 29)
+set(OPENMW_VERSION_MINOR 28)
 set(OPENMW_VERSION_RELEASE 0)
 
 set(OPENMW_VERSION_COMMITHASH "")
@@ -32,13 +32,22 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/.git)
 
             string(REGEX MATCH "^openmw-[^0-9]*[0-9]+\\.[0-9]+\\.[0-9]+.*" MATCH "${VERSION}")
             if(MATCH)
-                string(REGEX REPLACE "^openmw-([0-9]+)\\..*" "\\1" OPENMW_VERSION_MAJOR "${VERSION}")
-                string(REGEX REPLACE "^openmw-[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_MINOR "${VERSION}")
-                string(REGEX REPLACE "^openmw-[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" OPENMW_VERSION_RELEASE "${VERSION}")
+                string(REGEX REPLACE "^openmw-([0-9]+)\\..*" "\\1" GIT_VERSION_MAJOR "${VERSION}")
+                string(REGEX REPLACE "^openmw-[0-9]+\\.([0-9]+).*" "\\1" GIT_VERSION_MINOR "${VERSION}")
+                string(REGEX REPLACE "^openmw-[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" GIT_VERSION_RELEASE "${VERSION}")
 
-                set(OPENMW_VERSION "${OPENMW_VERSION_MAJOR}.${OPENMW_VERSION_MINOR}.${OPENMW_VERSION_RELEASE}")
-                set(OPENMW_VERSION_COMMITHASH "${COMMITHASH}")
-                set(OPENMW_VERSION_TAGHASH "${TAGHASH}")
+                set(GIT_VERSION "${GIT_VERSION_MAJOR}.${GIT_VERSION_MINOR}.${GIT_VERSION_RELEASE}")
+
+                if(NOT ${OPENMW_VERSION} STREQUAL ${GIT_VERSION})
+                    message(FATAL_ERROR "Silly Zini forgot to update the version again...")
+                else(NOT ${OPENMW_VERSION} STREQUAL ${GIT_VERSION})
+                    set(OPENMW_VERSION_MAJOR ${GIT_VERSION_MAJOR})
+                    set(OPENMW_VERSION_MINOR ${GIT_VERSION_MINOR})
+                    set(OPENMW_VERSION_RELEASE ${GIT_VERSION_RELEASE})
+
+                    set(OPENMW_VERSION_COMMITHASH "${COMMITHASH}")
+                    set(OPENMW_VERSION_TAGHASH "${TAGHASH}")
+                endif(NOT ${OPENMW_VERSION} STREQUAL ${GIT_VERSION})
 
                 message(STATUS "OpenMW version ${OPENMW_VERSION}")
             else(MATCH)

--- a/apps/launcher/maindialog.cpp
+++ b/apps/launcher/maindialog.cpp
@@ -76,17 +76,20 @@ Launcher::MainDialog::MainDialog(QWidget *parent)
     QString revision(OPENMW_VERSION_COMMITHASH);
     QString tag(OPENMW_VERSION_TAGHASH);
 
-    if (revision == tag) {
-        versionLabel->setText(tr("OpenMW %0 release").arg(OPENMW_VERSION));
-    } else {
-        versionLabel->setText(tr("OpenMW development (%0)").arg(revision.left(10)));
-    }
+    if (!revision.isEmpty() && !tag.isEmpty())
+    {
+        if (revision == tag) {
+            versionLabel->setText(tr("OpenMW %0 release").arg(OPENMW_VERSION));
+        } else {
+            versionLabel->setText(tr("OpenMW development (%0)").arg(revision.left(10)));
+        }
 
-    // Add the compile date and time
-    versionLabel->setToolTip(tr("Compiled on %0 %1").arg(QLocale(QLocale::C).toDate(QString(__DATE__).simplified(),
-                                                                                    QLatin1String("MMM d yyyy")).toString(Qt::SystemLocaleLongDate),
-                                                         QLocale(QLocale::C).toTime(QString(__TIME__).simplified(),
-                                                                                    QLatin1String("hh:mm:ss")).toString(Qt::SystemLocaleShortDate)));
+        // Add the compile date and time
+        versionLabel->setToolTip(tr("Compiled on %0 %1").arg(QLocale(QLocale::C).toDate(QString(__DATE__).simplified(),
+                                                                                        QLatin1String("MMM d yyyy")).toString(Qt::SystemLocaleLongDate),
+                                                             QLocale(QLocale::C).toTime(QString(__TIME__).simplified(),
+                                                                                        QLatin1String("hh:mm:ss")).toString(Qt::SystemLocaleShortDate)));
+    }
 
     createIcons();
 }

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -85,10 +85,6 @@ function(get_git_head_revision _refspecvar _hashvar)
 endfunction()
 
 function(git_describe _var)
-    if(NOT GIT_FOUND)
-        find_package(Git QUIET)
-    endif()
-
     #get_git_head_revision(refspec hash)
 
     if(NOT GIT_FOUND)
@@ -125,6 +121,20 @@ function(git_describe _var)
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     if(NOT res EQUAL 0)
+        execute_process(COMMAND
+                        "${GIT_EXECUTABLE}"
+                        describe
+                        "--always"
+                        WORKING_DIRECTORY
+                        "${CMAKE_SOURCE_DIR}"
+                        RESULT_VARIABLE
+                        res
+                        OUTPUT_VARIABLE
+                        out
+                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
+
+    if(NOT res EQUAL 0)
         set(out "${out}-${res}-NOTFOUND")
     endif()
 
@@ -133,7 +143,8 @@ endfunction()
 
 function(get_git_tag_revision _var)
     if(NOT GIT_FOUND)
-        find_package(Git QUIET)
+        set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+        return()
     endif()
 
     execute_process(COMMAND

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -121,20 +121,6 @@ function(git_describe _var)
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
     if(NOT res EQUAL 0)
-        execute_process(COMMAND
-                        "${GIT_EXECUTABLE}"
-                        describe
-                        "--always"
-                        WORKING_DIRECTORY
-                        "${CMAKE_SOURCE_DIR}"
-                        RESULT_VARIABLE
-                        res
-                        OUTPUT_VARIABLE
-                        out
-                        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    endif()
-
-    if(NOT res EQUAL 0)
         set(out "${out}-${res}-NOTFOUND")
     endif()
 


### PR DESCRIPTION
This should take care of the Git version woes, it won't try to retrieve a version from git if:
1. There is no .git directory
2. If there is a .git/shallow file, which means the source directory is a shallow git clone

This means the version has to be defined manually again, but I've added some sanity checking to make sure the version retrieved from git doesn't differ from the one specified in CMakeLists.txt 
