### PR TITLE
Fix file handles being left open on windows builds

### DIFF
--- a/components/files/lowlevelfile.cpp
+++ b/components/files/lowlevelfile.cpp
@@ -219,7 +219,7 @@ LowLevelFile::LowLevelFile ()
 
 LowLevelFile::~LowLevelFile ()
 {
-	if (mHandle == INVALID_HANDLE_VALUE)
+	if (mHandle != INVALID_HANDLE_VALUE)
 		CloseHandle (mHandle);
 }
 


### PR DESCRIPTION
This should fix the issue of unable to save over an existing save on windows.  Tested with 32bit and 64bit builds, Debug and Release.
