### PR TITLE
(#1191) Disallow picking up if inventory disabled

### DIFF
--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -514,6 +514,9 @@ namespace MWGui
 
     void InventoryWindow::pickUpObject (MWWorld::Ptr object)
     {
+        // If the inventory is not yet enabled, don't pick anything up
+        if (!MWBase::Environment::get().getWindowManager()->isAllowed(GW_Inventory))
+            return;
         // make sure the object is of a type that can be picked up
         std::string type = object.getTypeName();
         if ( (type != typeid(ESM::Apparatus).name())


### PR DESCRIPTION
Quickly fixes Bug #1191 by disallowing any sort of drag and drop if the window manager hasn't yet enabled the inventory.
This does not replicate the Vanilla behaviour completely:
- Once inventory is enabled you may still drag and drop the release papers into your inventory
- If you attempted to drag and drop the papers, leaving the menu will not activate the papers

I am willing to implement these missing behaviours, if it is needed. I would, however require a little advice as to how to do it. 
