### PR TITLE
Bug #1185 fix

### DIFF
--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -220,7 +220,7 @@ void MWState::StateManager::loadGame (const Character *character, const Slot *sl
 {
     try
     {
-        cleanup();
+        cleanup(true); // force cleanup before loading the records from the save
 
         mTimePlayed = slot->mProfile.mTimePlayed;
 


### PR DESCRIPTION
Apparently collision objects from cell 0,0 need to be unloaded first.
