### PR TITLE
Play item sound even if merchant doesn't purchase it.

### DIFF
--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -162,6 +162,7 @@ namespace MWGui
         }
 
         const ItemStack& item = mTradeModel->getItem(index);
+        std::string sound = MWWorld::Class::get(item.mBase).getDownSoundId(item.mBase);
 
         MWWorld::Ptr object = item.mBase;
         int count = item.mCount;
@@ -213,6 +214,7 @@ namespace MWGui
             int services = MWBase::Environment::get().getWindowManager()->getTradeWindow()->getMerchantServices();
             if (!MWWorld::Class::get(object).canSell(object, services))
             {
+                MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
                 MWBase::Environment::get().getWindowManager()->
                         messageBox("#{sBarterDialog4}");
                 return;


### PR DESCRIPTION
Playing the sound even when merchant won't accept the item is original Morrowind behavior.
