### PR TITLE
Play item sound when trying to sell a bound item, too.

### DIFF
--- a/apps/openmw/mwgui/inventorywindow.cpp
+++ b/apps/openmw/mwgui/inventorywindow.cpp
@@ -171,6 +171,7 @@ namespace MWGui
         if (item.mBase.getCellRef().mRefID.size() > 6
                 && item.mBase.getCellRef().mRefID.substr(0,6) == "bound_")
         {
+            MWBase::Environment::get().getSoundManager()->playSound (sound, 1.0, 1.0);
             MWBase::Environment::get().getWindowManager()->messageBox("#{sBarterDialog12}");
             return;
         }


### PR DESCRIPTION
What's strange is that the player could also drag bound items around in original Morrowind (but still not sell them). But that probably isn't worth implementing.
