### PR TITLE
Update weapon icon in HUD when save is loaded.

### DIFF
--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -25,6 +25,7 @@
 #include "../mwworld/player.hpp"
 #include "../mwworld/class.hpp"
 #include "../mwworld/cellstore.hpp"
+#include "../mwworld/inventorystore.hpp"
 
 #include "../mwmechanics/npcstats.hpp"
 
@@ -303,6 +304,10 @@ void MWState::StateManager::loadGame (const Character *character, const Slot *sl
         MWBase::Environment::get().getMechanicsManager()->playerLoaded();
 
         MWWorld::Ptr ptr = MWBase::Environment::get().getWorld()->getPlayerPtr();
+        
+        //Update the weapon icon in the hud with whatever the player is currently holding.
+        MWWorld::InventoryStore& invStore = ptr.getClass().getInventoryStore(ptr);
+        MWBase::Environment::get().getWindowManager()->setSelectedWeapon(*invStore.getSlot(MWWorld::InventoryStore::Slot_CarriedRight));
 
         ESM::CellId cellId = ptr.getCell()->getCell()->getCellId();
 

--- a/apps/openmw/mwstate/statemanagerimp.cpp
+++ b/apps/openmw/mwstate/statemanagerimp.cpp
@@ -307,7 +307,10 @@ void MWState::StateManager::loadGame (const Character *character, const Slot *sl
         
         //Update the weapon icon in the hud with whatever the player is currently holding.
         MWWorld::InventoryStore& invStore = ptr.getClass().getInventoryStore(ptr);
-        MWBase::Environment::get().getWindowManager()->setSelectedWeapon(*invStore.getSlot(MWWorld::InventoryStore::Slot_CarriedRight));
+        MWWorld::ContainerStoreIterator item = invStore.getSlot(MWWorld::InventoryStore::Slot_CarriedRight);
+        
+        if (item != invStore.end())
+            MWBase::Environment::get().getWindowManager()->setSelectedWeapon(*item);
 
         ESM::CellId cellId = ptr.getCell()->getCell()->getCellId();
 


### PR DESCRIPTION
Currently the weapon icon is "Unarmed" no matter what weapon is equipped at save load.
